### PR TITLE
2.3.x.pgraster

### DIFF
--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -298,6 +298,10 @@ void read_grayscale_band(mapnik::raster_ptr raster,
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
       val = reader();
+      // Apply harse type clipping rules ala GDAL
+      if ( val < 0 ) val = 0;
+      if ( val > 255 ) val = 255;
+      // Calculate pixel offset
       off = y * width * ps + x * ps;
       // Pixel space is RGBA, fill all w/ same value for Grey
       data[off+0] = val;

--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -192,10 +192,14 @@ void read_data_band(mapnik::raster_ptr raster,
   raster->premultiplied_alpha_ = true;
 
   float* data = (float*)image.getBytes();
-  double val;
   double nodataval;
-  nodataval = reader(); // nodata value, need to read anyway
-  if ( hasnodata ) raster->set_nodata(nodataval);
+  double val = reader(); // read nodata value, whether we use it or not (here, we don't)
+  
+  if ( hasnodata ) {
+    raster->set_nodata(nodataval);
+    nodataval = val;
+  }
+
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
       val = reader();

--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -65,12 +65,12 @@ read_uint16(const boost::uint8_t** from, boost::uint8_t littleEndian) {
     return ret;
 }
 
-int16_t
-read_int16(const uint8_t** from, uint8_t littleEndian) {
-    assert(NULL != from);
-
-    return read_uint16(from, littleEndian);
-}
+// int16_t
+// read_int16(const uint8_t** from, uint8_t littleEndian) {
+//     assert(NULL != from);
+//
+//     return read_uint16(from, littleEndian);
+// }
 
 double
 read_float64(const boost::uint8_t** from, boost::uint8_t littleEndian) {
@@ -185,10 +185,6 @@ void read_data_band(mapnik::raster_ptr raster,
 {
   mapnik::image_data_32 & image = raster->data_;
 
-  // Start with plain white (ABGR or RGBA depending on endiannes)
-  // TODO: set to transparent instead?
-  image.set(0xffffffff);
-
   raster->premultiplied_alpha_ = true;
 
   float* data = (float*)image.getBytes();
@@ -196,8 +192,8 @@ void read_data_band(mapnik::raster_ptr raster,
   double val = reader(); // read nodata value, whether we use it or not (here, we don't)
   
   if ( hasnodata ) {
-    raster->set_nodata(nodataval);
     nodataval = val;
+    raster->set_nodata(nodataval);
   }
 
   for (int y=0; y<height; ++y) {
@@ -284,6 +280,9 @@ void read_grayscale_band(mapnik::raster_ptr raster,
   mapnik::image_data_32 & image = raster->data_;
 
   raster->premultiplied_alpha_ = true;
+
+  // Start with black and transparent full on
+  image.set(0x00000000);
 
   int val;
   int nodataval;
@@ -379,8 +378,8 @@ pgraster_wkb_reader::read_rgba(mapnik::raster_ptr raster)
 {
   mapnik::image_data_32 & image = raster->data_;
 
-  // Start with plain white (ABGR or RGBA depending on endiannes)
-  image.set(0xffffffff);
+  // Start with white and transparent full on
+  image.set(0xffffff00);
  
   raster->premultiplied_alpha_ = true;
 

--- a/plugins/input/pgraster/pgraster_wkb_reader.hpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.hpp
@@ -50,7 +50,7 @@ class pgraster_wkb_reader
 public:
 
   pgraster_wkb_reader(const uint8_t* wkb, int size, int bnd=0)
-    : wkbsize_(size), wkb_(wkb), wkbend_(wkb+size), ptr_(wkb), bandno_(bnd) 
+    : ptr_(wkb), bandno_(bnd) 
   {}
 
   mapnik::raster_ptr get_raster();
@@ -72,9 +72,6 @@ private:
   void read_grayscale(mapnik::raster_ptr raster);
   void read_rgba(mapnik::raster_ptr raster);
 
-  int wkbsize_;
-  const uint8_t* wkb_;
-  const uint8_t* wkbend_;
   const uint8_t* ptr_;
   uint8_t endian_;
   int bandno_;


### PR DESCRIPTION
This PR doesn't change configuration or parameters at all, it just addresses [two bugs](https://github.com/mapnik/mapnik/issues/2661) filed against mapnik that affect using mapnik to render pgraster inputs.
- rendering of single-band inputs as grey-scale did not correctly make nodata pixels transparent in the output
- rendering of 16-bit single-band inputs displayed a wrap-around effect
