### PR TITLE
TWKB filtering and simplifying operations harmonized

### DIFF
--- a/plugins/input/postgis/README.md
+++ b/plugins/input/postgis/README.md
@@ -16,17 +16,18 @@
 * `extent_from_subquery`: If trying to estimate extent, and SQL is subquery, estimate on that? (default: false)
 * `max_async_connection`: If > 1, turn on the asyncronous connection feature. (default: 1)
 * `simplify_geometries`: Use PostGIS ST_Simplify call on the geometry to make input data smaller. (default: false)
-* `simplify_dp_ratio`: Use a PostGIS simplification factor of this proportion of the ground size of a pixel. For example, if pixels are 40m square for this rendering, and the ratio is set to 1/20, then `ST_Simplify(geom, 2)` would be used. (default: 1/20)
+* `simplify_dp_ratio`: Use a PostGIS simplification factor of this proportion of the ground size of a pixel. For example, if pixels are 20m square for this rendering, and the ratio is set to 0.05, then `ST_Simplify(geom, 1.0)` would be used. (default: 0.05)
 
-## 2.3.x.twkb
+## 2.3.x.cartodb
 
-* `simplify_snap_ratio`: Use PostGIS `ST_SnapToGrid` call to make the input data smaller. This is applied to geometry **before** any `ST_Simplify` is called, so should use a tolerance smaller than the simplify tolerance. Tolerance is expressed as a proportion of a pixel, as with `simplify_dp_ratio`. (default: 1/40)
-
-These features all require PostGIS 2.2+, as they use features that do not appear in earlier PostGIS versions.
+These features all require PostGIS 2.2+ (or a backport), as they use features that do not appear in earlier PostGIS versions. When `twkb_encoding` is true, only `twkb_rounding_adjustment` has effect, other parameters are ignored as filtering and simplification are slaved to the TWKB rounding level.
 
 * `twkb_encoding`: Use TWKB to encode geometries for transport from the database to the renderer instead of standard WKB? (default: false)
+* `twkb_rounding_adjustment`: Adjust the resolution the TWKB aims for. At 0.5, the rounding aims for a maximum coarseness of one pixel. At 0.0 rounding rarely exceeds about 0.2 pixels and gets as small as 0.05 pixels at times. Recommended range, -0.5 to 0.5. (Default: 0.0).
 * `simplify_dp_preserve`: Set the `preserve` option in `ST_Simplify` when in `simplify_geometries` mode? This will ensure that features that get simplified down to nothing aren't dropped but are retained in point-like form. Useful for rendering to avoid gaps where small feature "disappear". (default: false)
-* `simplify_clip_resolution`: In non-zero, sets the map scale at which geometries start getting clipped to the rendering window. (default: 0.0)
+* `simplify_clip_resolution`: If non-zero, sets the map scale at which geometries start getting clipped to the rendering window. (default: 0.0)
+* `simplify_prefilter`: If non-zero, runs a distance filter on geometries to ensure all points are at least a certain distance apart. Expressed as a proportion of the current pixel size. (default: 0.0, feature is OFF) (recommended: 0.5)
+* `simplify_snap_ratio`: Use PostGIS `ST_SnapToGrid` call to make the input data smaller. This is applied to geometry **before** any `ST_Simplify` is called, so should use a tolerance smaller than the simplify tolerance. Tolerance is expressed as a proportion of a pixel, as with `simplify_dp_ratio`. (default: 1/40)
 
 ## SQL Tokens
 

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -115,8 +115,10 @@ private:
     int max_async_connections_;
     bool asynchronous_request_;
     bool twkb_encoding_;
+    mapnik::value_double twkb_rounding_adjustment_;
     mapnik::value_double simplify_snap_ratio_;
     mapnik::value_double simplify_dp_ratio_;
+    mapnik::value_double simplify_prefilter_;
     bool simplify_dp_preserve_;
     mapnik::value_double simplify_clip_resolution_;
     int intersect_min_scale_;


### PR DESCRIPTION
Tie TWKB filtering and simplifying operations to the underlying rounding resolution for hopefully better output results.

This PR should only be used in TWKB mode with a PostGIS 2.1 updated as in https://github.com/CartoDB/postgis/pull/3, or against PostGIS 2.2. In WKB mode it will work fine against un-patched PostGIS 2.1
