### PR TITLE
[WIP] 18 performance stats

### DIFF
--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -82,6 +82,10 @@ public:
         return timer_stats_[metric_name];
     }
 
+    void reset(std::string metric_name) {
+        timer_stats_.erase(metric_name);
+    }
+
 private:
     std::unordered_map<std::string, timer_metrics> timer_stats_;
 };

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -79,6 +79,11 @@ public:
         timer_stats_[metric_name] = metrics;
     }
 
+    timer_metrics get(std::string metric_name)
+    {
+        return timer_stats_[metric_name];
+    }
+
 private:
     std::unordered_map<std::string, timer_metrics> timer_stats_;
 };

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -71,9 +71,7 @@ class timer_stats_
 public:
     void add(std::string metric_name, double cpu_elapsed, double wall_clock_elapsed)
     {
-        timer_metrics metrics;
-
-        metrics = timer_stats_[metric_name];
+        timer_metrics& metrics = timer_stats_[metric_name];
         metrics.cpu_elapsed += cpu_elapsed;
         metrics.wall_clock_elapsed += wall_clock_elapsed;
         timer_stats_[metric_name] = metrics;

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -30,6 +30,7 @@
 #include <iomanip>
 #include <ctime>
 #include <unordered_map>
+#include <iterator>
 
 #ifdef _WINDOWS
 #define NOMINMAX
@@ -66,6 +67,8 @@ struct timer_metrics {
     double wall_clock_elapsed;
 };
 
+typedef std::unordered_map<std::string, timer_metrics> metrics_hash_t;
+
 class timer_stats_
 {
 public:
@@ -90,9 +93,16 @@ public:
         timer_stats_.clear();
     }
 
+    metrics_hash_t::iterator begin() {
+        return timer_stats_.begin();
+    }
+
+    metrics_hash_t::iterator end() {
+        return timer_stats_.end();
+    }
 
 private:
-    std::unordered_map<std::string, timer_metrics> timer_stats_;
+    metrics_hash_t timer_stats_;
 };
 
 timer_stats_ timer_stats;

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -69,7 +69,7 @@ struct timer_metrics {
 class timer_stats_
 {
 public:
-    void add(std::string metric_name, double cpu_elapsed, double wall_clock_elapsed)
+    void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
     {
         timer_metrics& metrics = timer_stats_[metric_name];
         metrics.cpu_elapsed += cpu_elapsed;
@@ -77,7 +77,7 @@ public:
         timer_stats_[metric_name] = metrics;
     }
 
-    timer_metrics get(std::string metric_name)
+    timer_metrics get(std::string const& metric_name)
     {
         return timer_stats_[metric_name];
     }

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -86,6 +86,11 @@ public:
         timer_stats_.erase(metric_name);
     }
 
+    void reset_all() {
+        timer_stats_.clear();
+    }
+
+
 private:
     std::unordered_map<std::string, timer_metrics> timer_stats_;
 };

--- a/include/mapnik/timer.hpp
+++ b/include/mapnik/timer.hpp
@@ -66,7 +66,25 @@ struct timer_metrics {
     double wall_clock_elapsed;
 };
 
-std::unordered_map<std::string, timer_metrics> timer_stats;
+class timer_stats_
+{
+public:
+    void add(std::string metric_name, double cpu_elapsed, double wall_clock_elapsed)
+    {
+        timer_metrics metrics;
+
+        metrics = timer_stats_[metric_name];
+        metrics.cpu_elapsed += cpu_elapsed;
+        metrics.wall_clock_elapsed += wall_clock_elapsed;
+        timer_stats_[metric_name] = metrics;
+    }
+
+private:
+    std::unordered_map<std::string, timer_metrics> timer_stats_;
+};
+
+timer_stats_ timer_stats;
+
 
 
 // Measure times in both wall clock time and CPU times. Results are returned in milliseconds.
@@ -146,7 +164,7 @@ public:
         timer::stop();
         try
         {
-            timer_stats.insert({metric_name_, {cpu_elapsed(), wall_clock_elapsed()}});
+            timer_stats.add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
         }
         catch (...) {} // eat any exceptions
     }


### PR DESCRIPTION
Hey, I just wanted you to take a quick look at these ideas in code. The code is crappy, lacks tests, breaks for sure (as I modified the API of the stats) and can be improved.

I tested it using a file like this:
```c++
#include <unistd.h>
#include <iostream>
#include "include/mapnik/timer.hpp"

/**
 * Compile it like this:
 * g++-4.9 -std=c++11 metrics-test.cpp -o metrics-test
 */
int main(int argc, char** argv)
{
    {
        mapnik::progress_timer __stats__("dummy::sleep");
        usleep(100000);
    }

    //mapnik::timer_stats.reset("dummy::sleep");

    {
        mapnik::progress_timer __stats__("dummy::sleep");
        usleep(100000);
    }

    //mapnik::timer_stats.reset_all();

    {
        mapnik::progress_timer __stats__("busy::wait");
        unsigned long int counter = 0;
        for(unsigned int i=0; i<10000; i++) {
            for(unsigned int j=0; j<10000; j++) {
                counter++;
            }
        }
    }

    for(auto metric : mapnik::timer_stats) {
        std::cout << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;
    }


    // std::cout << "dummy::sleep.cpu_elapsed = " << mapnik::timer_stats.get("dummy::sleep").cpu_elapsed << " ms" << std::endl;
    // std::cout << "dummy::sleep.wall_clock_elapsed = " << mapnik::timer_stats.get("dummy::sleep").wall_clock_elapsed << " ms" << std::endl;
    // std::cout << std::endl;
    // std::cout << "busy::wait.cpu_elapsed = " << mapnik::timer_stats.get("busy::wait").cpu_elapsed << " ms" << std::endl;
    // std::cout << "busy::wait.wall_clock_elapsed = " << mapnik::timer_stats.get("busy::wait").wall_clock_elapsed << " ms" << std::endl;

    return 0;
}
```

and running it on my machine outputs this stuff:
```
$ time ./metrics-test 
busy::wait	cpu_time = 379.447 ms	wall_time = 379.572 ms
dummy::sleep	cpu_time = 0.052 ms	wall_time = 200.225 ms

real	0m0.583s
user	0m0.380s
sys	0m0.000s
```

The idea is to use the same code to collect stats and expose the `get` or some other custom method to spit them out to wrappers and upper layers.

Maybe instead of just an unordered_map (hash) we'd need to use an LRU in-memory cache or something like that (circular buffer, whatever, you name it) to avoid big memory footprint. Maybe it is better to have a separate class to gather these stats in production and be more selective.

Comments in this early stage are more than welcome cc/ @javisantana @jgoizueta 