### PR TITLE
V3.0.15 carto.cached marker rendering

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "test/data-visual"]
 	path = test/data-visual
 	url = https://github.com/CartoDB/test-data-visual.git
-	branch = 3.0.15-carto
+	branch = v3.0.15-carto.cached-marker-rendering
 [submodule "deps/mapbox/variant"]
 	path = deps/mapbox/variant
 	url = https://github.com/mapbox/variant.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ before_install:
  - export COVERAGE=${COVERAGE:-false}
  - export BENCH=${BENCH:-false}
  - git_submodule_update --init
+ - git_submodule_update --remote
 
 install:
  - on 'osx' export DATA_PATH=$(brew --prefix)/var/postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,6 @@ script:
  - RESULT=0
  - make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
- - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ ${TRAVIS_OS_NAME} != 'osx' ]]; then false; fi;
+ - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
     - os: osx
       compiler: ": clang-osx"
       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
-      osx_image: xcode7.3 # upgrades clang from 6 -> 7
+      osx_image: xcode9.2 # this seems to be in sync with Linux clang
       env: JOBS=4 CXX="ccache clang++ -Qunused-arguments"
 
 before_install:
@@ -109,4 +109,4 @@ script:
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
  - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
- - enabled ${BENCH} make bench
+ - enabled ${BENCH} make bench - enabled ${BENCH} make bench - enabled ${BENCH} make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,6 @@ script:
  - RESULT=0
  - make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
- - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
+ - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ ${TRAVIS_OS_NAME} != 'osx' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench

--- a/benchmark/data/random_markers.xml
+++ b/benchmark/data/random_markers.xml
@@ -1,0 +1,25 @@
+<Map background-color="steelblue" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Style name="test" opacity="1.0">
+    <Rule>
+      <Filter>[class] = 0</Filter>
+      <MarkersSymbolizer opacity="0.3" allow-overlap="1" fill="rgb(255,0,39)" fill-opacity="0.7" marker-type="ellipse" placement="point" stroke="rgb(255,255,255)" stroke-opacity="0.9" stroke-width="0" width="3" comp-op="src-over" /> 
+    </Rule>
+    <Rule>
+      <Filter>[class] = 1</Filter>
+      <MarkersSymbolizer opacity="0.7" allow-overlap="1" fill="rgb(0,255,0)" fill-opacity="0.9" marker-type="ellipse" placement="point" stroke="rgb(0,0,0)" stroke-opacity="0.8" stroke-width="0" width="4" comp-op="src-over" /> 
+    </Rule>
+  </Style>
+  <Layer name="test" srs="+proj=merc +datum=WGS84 +over">
+    <StyleName>test</StyleName>
+    <Datasource>
+       <Parameter name="type"><![CDATA[postgis]]></Parameter>
+       <Parameter name="dbname">test_random_points</Parameter>
+       <Parameter name="extent_from_subquery">true</Parameter>
+       <Parameter name="geometry_field"><![CDATA[geom]]></Parameter>
+       <Parameter name="srid"><![CDATA[3857]]></Parameter>
+       <Parameter name="table"><![CDATA[
+            (select geom, attr as class from test_random_points) as s
+       ]]></Parameter>
+    </Datasource>
+  </Layer>
+</Map>

--- a/benchmark/run
+++ b/benchmark/run
@@ -66,3 +66,16 @@ run test_offset_converter 10 1000
 ./benchmark/out/test_quad_tree \
   --iterations 1000 \
   --threads 10
+
+dropdb --if-exists test_random_points
+createdb -T template_postgis test_random_points
+python benchmark/utils/random_points.py test_random_points 100000 | psql -q test_random_points
+
+./benchmark/out/test_rendering \
+  --name "100000 marker rendering" \
+  --map benchmark/data/random_markers.xml  \
+  --extent -180.0,-120.0,180.0,120.0 \
+  --width 600 \
+  --height 600 \
+  --iterations 10 \
+  --threads 1

--- a/benchmark/utils/random_points.py
+++ b/benchmark/utils/random_points.py
@@ -1,0 +1,45 @@
+import math
+import json
+import random
+import argparse
+
+def genRandomFeatures(n):
+  features = []
+  for i in range(0, n):
+    lat = (random.random() - 0.5) * 360.0
+    lng = (random.random() - 0.5) * 180.0
+    geom = { 'type': 'Point', 'coordinates': [lat, lng] }
+    props = { 'class': 1 if random.random() > 0.5 else 0 }
+    feature = { 'type': 'Feature', 'properties': props, 'geometry': geom }
+    features.append(feature)
+  return features
+
+def genGridFeatures(nx, ny):
+  features = []
+  for i in range(0, nx):
+    for j in range(0, ny):
+      lat = (i - 0.5) * 360.0 / nx
+      lng = (j - 0.5) * 180.0 / ny
+      geom = { 'type': 'Point', 'coordinates': [lat, lng] }
+      props = { 'class': 1 if random.random() > 0.5 else 0 }
+      feature = { 'type': 'Feature', 'properties': props, 'geometry': geom }
+      features.append(feature)
+  return features
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(dest='tableName', help='The name of the db table')
+  parser.add_argument(dest='numPoints', type=int, help='The number of random points')
+
+  args = parser.parse_args()
+
+  features = genRandomFeatures(args.numPoints)
+
+  print("DROP TABLE IF EXISTS %s;" % args.tableName)
+  print("CREATE TABLE %s(gid serial PRIMARY KEY, geom GEOMETRY, attr NUMERIC);" % args.tableName)
+  for feature in features:
+    geom = "POINT(%g %g)" % tuple(feature['geometry']['coordinates'])
+    print("INSERT INTO %s VALUES (DEFAULT, GeomFromEWKT('SRID=4326;%s'), %d);" % (args.tableName, geom, feature['properties']['class']))
+
+if __name__ == "__main__":
+  main()

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -51,6 +51,8 @@ namespace mapnik {
 
 namespace detail {
 
+using svg_path_attrib_data = std::array<unsigned char, sizeof(svg::path_attributes)>;
+
 template <typename SvgRenderer, typename BufferType, typename RasterizerType>
 struct agg_markers_renderer_context : markers_renderer_context
 {
@@ -67,10 +69,10 @@ struct agg_markers_renderer_context : markers_renderer_context
       : buf_(buf),
         pixf_(buf_),
         renb_(pixf_),
-        ras_(ras)
+        ras_(ras),
+        comp_op_(get<composite_mode_e, keys::comp_op>(sym, feature, vars))
     {
-        auto comp_op = get<composite_mode_e, keys::comp_op>(sym, feature, vars);
-        pixf_.comp_op(static_cast<agg::comp_op_e>(comp_op));
+        pixf_.comp_op(static_cast<agg::comp_op_e>(comp_op_));
     }
 
     virtual void render_marker(svg_path_ptr const& src,
@@ -79,9 +81,130 @@ struct agg_markers_renderer_context : markers_renderer_context
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
+        // We try to reuse existing marker images. We currently do it only for single attribute set.
+        if (attrs.size() == 1)
+        {
+            // Markers are generally drawn using 2 shapes. To be safe, check that at most one of the shapes has transparency.
+            // Also, check that transform does not use any scaling/shearing.
+            bool cacheable = marker_tr.sx == 1.0 && marker_tr.sy == 1.0 && marker_tr.shx == 0.0 && marker_tr.shy == 0.0;
+            if (cacheable)
+            {
+                // Calculate canvas offsets
+                double margin = 0.0;
+                if (attrs[0].stroke_flag || attrs[0].stroke_gradient.get_gradient_type() != NO_GRADIENT)
+                {
+                    margin = std::abs(attrs[0].stroke_width);
+                }
+                double x0 = std::floor(src->bounding_box().minx() - margin);
+                double y0 = std::floor(src->bounding_box().miny() - margin);
+
+                // Now calculate subpixel offset and sample index
+                double dx = marker_tr.tx - std::floor(marker_tr.tx);
+                double dy = marker_tr.ty - std::floor(marker_tr.ty);
+
+                double sample_x = std::floor(dx * sampling_rate);
+                double sample_y = std::floor(dy * sampling_rate);
+
+                int sample_idx = static_cast<int>(sample_y) * sampling_rate + static_cast<int>(sample_x);
+
+                std::tuple<svg_path_ptr, svg_path_attrib_data, int> key(src, *reinterpret_cast<svg_path_attrib_data const*>(&attrs[0]), sample_idx);
+
+                auto it = cached_images_.find(key);
+                if (it == cached_images_.end())
+                {
+                    // Calculate canvas size
+                    int width  = static_cast<int>(std::ceil(src->bounding_box().width()  + 2.0 * margin)) + 2;
+                    int height = static_cast<int>(std::ceil(src->bounding_box().height() + 2.0 * margin)) + 2;
+
+                    // Reset clip box
+                    ras_.clip_box(0, 0, width, height);
+
+                    // Build local transformation matrix by resetting translation coordinates
+                    agg::trans_affine marker_tr_copy(marker_tr);
+                    marker_tr_copy.tx = sample_x / sampling_rate - x0;
+                    marker_tr_copy.ty = sample_y / sampling_rate - y0;
+
+                    // Create fill image
+                    std::shared_ptr<image_rgba8> fill_img;
+                    if (attrs[0].fill_flag || attrs[0].fill_gradient.get_gradient_type() != NO_GRADIENT)
+                    {
+                        fill_img = std::make_shared<image_rgba8>(width, height, true);
+
+                        agg::rendering_buffer buf(fill_img->bytes(), width, height, 4 * width);
+                        pixfmt_type pixf(buf);
+                        renderer_base renb(pixf);
+
+                        auto attrs_copy = attrs;
+                        attrs_copy[0].stroke_flag = false;
+                        attrs_copy[0].stroke_gradient.set_gradient_type(NO_GRADIENT);
+
+                        SvgRenderer svg_renderer(path, attrs_copy);
+                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, false);
+
+                        if (std::all_of(fill_img->begin(), fill_img->end(), [](uint32_t val) { return val == 0; }))
+                        {
+                            fill_img.reset();
+                        }
+                    }
+
+                    // Create stroke image
+                    std::shared_ptr<image_rgba8> stroke_img;
+                    if (attrs[0].stroke_flag || attrs[0].stroke_gradient.get_gradient_type() != NO_GRADIENT)
+                    {
+                        stroke_img = std::make_shared<image_rgba8>(width, height, true);
+
+                        agg::rendering_buffer buf(stroke_img->bytes(), width, height, 4 * width);
+                        pixfmt_type pixf(buf);
+                        renderer_base renb(pixf);
+
+                        auto attrs_copy = attrs;
+                        attrs_copy[0].fill_flag = false;
+                        attrs_copy[0].fill_gradient.set_gradient_type(NO_GRADIENT);
+
+                        SvgRenderer svg_renderer(path, attrs_copy);
+                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, false);
+
+                        if (std::all_of(stroke_img->begin(), stroke_img->end(), [](uint32_t val) { return val == 0; }))
+                        {
+                            stroke_img.reset();
+                        }
+                    }
+
+                    if (cached_images_.size() > cache_size)
+                    {
+                        cached_images_.erase(cached_images_.begin());
+                    }
+                    it = cached_images_.emplace(key, std::make_pair(fill_img, stroke_img)).first;
+
+                    // Restore clip box
+                    ras_.clip_box(0, 0, pixf_.width(), pixf_.height());
+                }
+
+                // Set up blitting transformation. We will add a small offset due to sampling
+                agg::trans_affine marker_tr_copy(marker_tr);
+                marker_tr_copy.tx = std::floor(marker_tr.tx) + (dx - sample_x / sampling_rate) + x0;
+                marker_tr_copy.ty = std::floor(marker_tr.ty) + (dy - sample_y / sampling_rate) + y0;
+                marker_tr_copy.sx = 1.0;
+                marker_tr_copy.sy = 1.0;
+                marker_tr_copy.shx = 0.0;
+                marker_tr_copy.shy = 0.0;
+
+                // Blit stroke and fill images
+                if (it->second.first)
+                {
+                    render_raster_marker(renb_, ras_, *it->second.first, marker_tr_copy, params.opacity, params.scale_factor, params.snap_to_pixels);
+                }
+                if (it->second.second)
+                {
+                    render_raster_marker(renb_, ras_, *it->second.second, marker_tr_copy, params.opacity, params.scale_factor, params.snap_to_pixels);
+                }
+                return;
+            }
+        }
+
+        // Fallback to non-cached rendering path
         SvgRenderer svg_renderer(path, attrs);
-        render_vector_marker(svg_renderer, ras_, renb_, src->bounding_box(),
-                             marker_tr, params.opacity, params.snap_to_pixels);
+        render_vector_marker(svg_renderer, ras_, renb_, src->bounding_box(), marker_tr, params.opacity, params.snap_to_pixels);
     }
 
 
@@ -100,7 +223,16 @@ private:
     pixfmt_type pixf_;
     renderer_base renb_;
     RasterizerType & ras_;
+    composite_mode_e comp_op_;
+
+    static std::map<std::tuple<svg_path_ptr, svg_path_attrib_data, int>, std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>> cached_images_;
+
+    static constexpr size_t cache_size = 128; // maximum number of images to cache
+    static constexpr int sampling_rate = 4; // this determines subpixel precision. The larger the value, the closer the solution will be compared to the reference but will reduce the cache hits
 };
+
+template <typename SvgRenderer, typename BufferType, typename RasterizerType>
+std::map<std::tuple<svg_path_ptr, svg_path_attrib_data, int>, std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>> agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>::cached_images_;
 
 } // namespace detail
 

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -112,6 +112,10 @@ struct agg_markers_renderer_context : markers_renderer_context
 
                 std::tuple<svg_path_ptr, svg_path_attrib_data, int> key(src, *reinterpret_cast<svg_path_attrib_data const*>(&attrs[0]), sample_idx);
 
+#ifdef MAPNIK_THREADSAFE
+                std::lock_guard<std::mutex> lock(mutex_);
+#endif
+
                 auto it = cached_images_.find(key);
                 if (it == cached_images_.end())
                 {
@@ -229,6 +233,10 @@ private:
     RasterizerType & ras_;
     composite_mode_e comp_op_;
 
+#ifdef MAPNIK_THREADSAFE
+    static std::mutex mutex_;
+#endif
+
     static std::map<
                std::tuple<svg_path_ptr, svg_path_attrib_data, int>,
                std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
@@ -237,6 +245,11 @@ private:
     static constexpr size_t cache_size = 128; // maximum number of images to cache
     static constexpr int sampling_rate = 4; // this determines subpixel precision. The larger the value, the closer the solution will be compared to the reference but will reduce the cache hits
 };
+
+#ifdef MAPNIK_THREADSAFE
+template <typename SvgRenderer, typename BufferType, typename RasterizerType>
+std::mutex agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>::mutex_;
+#endif
 
 template <typename SvgRenderer, typename BufferType, typename RasterizerType>
 std::map<

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -242,7 +242,7 @@ private:
                std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
            > cached_images_;
 
-    static constexpr size_t cache_size = 128; // maximum number of images to cache
+    static constexpr size_t cache_size = 4096; // maximum number of images to cache. Note that the number of actual images stored depends also on sampling_rate
     static constexpr int sampling_rate = 4; // this determines subpixel precision. The larger the value, the closer the solution will be compared to the reference but will reduce the cache hits
 };
 

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -81,12 +81,15 @@ struct agg_markers_renderer_context : markers_renderer_context
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
-        // We try to reuse existing marker images. We currently do it only for single attribute set.
+        // We try to reuse existing marker images.
+        // We currently do it only for single attribute set.
         if (attrs.size() == 1)
         {
-            // Markers are generally drawn using 2 shapes. To be safe, check that at most one of the shapes has transparency.
+            // Markers are generally drawn using 2 shapes. To be safe, check
+            // that at most one of the shapes has transparency.
             // Also, check that transform does not use any scaling/shearing.
-            bool cacheable = marker_tr.sx == 1.0 && marker_tr.sy == 1.0 && marker_tr.shx == 0.0 && marker_tr.shy == 0.0;
+            bool cacheable = marker_tr.sx == 1.0 && marker_tr.sy == 1.0 &&
+                             marker_tr.shx == 0.0 && marker_tr.shy == 0.0;
             if (cacheable)
             {
                 // Calculate canvas offsets
@@ -143,7 +146,7 @@ struct agg_markers_renderer_context : markers_renderer_context
 
                         if (std::all_of(fill_img->begin(), fill_img->end(), [](uint32_t val) { return val == 0; }))
                         {
-                            fill_img.reset();
+                            fill_img.reset(); // optimization, can ignore image
                         }
                     }
 
@@ -166,7 +169,7 @@ struct agg_markers_renderer_context : markers_renderer_context
 
                         if (std::all_of(stroke_img->begin(), stroke_img->end(), [](uint32_t val) { return val == 0; }))
                         {
-                            stroke_img.reset();
+                            stroke_img.reset(); // optimization, can ignore image
                         }
                     }
 
@@ -212,8 +215,9 @@ struct agg_markers_renderer_context : markers_renderer_context
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
-        // In the long term this should be a visitor pattern based on the type of
-        // render src provided that converts the destination pixel type required.
+        // In the long term this should be a visitor pattern based on the
+        // type of render src provided that converts the destination pixel
+        // type required.
         render_raster_marker(renb_, ras_, src, marker_tr, params.opacity,
                              params.scale_factor, params.snap_to_pixels);
     }
@@ -225,14 +229,20 @@ private:
     RasterizerType & ras_;
     composite_mode_e comp_op_;
 
-    static std::map<std::tuple<svg_path_ptr, svg_path_attrib_data, int>, std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>> cached_images_;
+    static std::map<
+               std::tuple<svg_path_ptr, svg_path_attrib_data, int>,
+               std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
+           > cached_images_;
 
     static constexpr size_t cache_size = 128; // maximum number of images to cache
     static constexpr int sampling_rate = 4; // this determines subpixel precision. The larger the value, the closer the solution will be compared to the reference but will reduce the cache hits
 };
 
 template <typename SvgRenderer, typename BufferType, typename RasterizerType>
-std::map<std::tuple<svg_path_ptr, svg_path_attrib_data, int>, std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>> agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>::cached_images_;
+std::map<
+    std::tuple<svg_path_ptr, svg_path_attrib_data, int>,
+    std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
+> agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>::cached_images_;
 
 } // namespace detail
 

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -168,11 +168,11 @@ void load_map(Map & map, std::string const& filename, bool strict, std::string b
     {
         for (auto & rule : style_it->second.get_rules_nonconst())
         {
-            for (auto sym_it = rule.begin(); sym_it != rule.end(); sym_it++)
+            for (auto & sym : rule)
             {
-                if (sym_it->is<markers_symbolizer>())
+                if (sym.is<markers_symbolizer>())
                 {
-                    markers_symbolizer & marker = sym_it->get<markers_symbolizer>();
+                    markers_symbolizer & marker = sym.get<markers_symbolizer>();
                     auto prop_it = marker.properties.find(keys::allow_overlap);
                     if (prop_it != marker.properties.end())
                     {
@@ -195,11 +195,11 @@ void load_map(Map & map, std::string const& filename, bool strict, std::string b
         {
             for (auto & rule : style_it->second.get_rules_nonconst())
             {
-                for (auto sym_it = rule.begin(); sym_it != rule.end(); sym_it++)
+                for (auto & sym : rule)
                 {
-                    if (sym_it->is<markers_symbolizer>())
+                    if (sym.is<markers_symbolizer>())
                     {
-                        markers_symbolizer & marker = sym_it->get<markers_symbolizer>();
+                        markers_symbolizer & marker = sym.get<markers_symbolizer>();
                         marker.properties[keys::ignore_placement] = true;
                     }
                 }

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -25,7 +25,6 @@
 #include <mapnik/svg/svg_path_adapter.hpp>
 #include <mapnik/marker_cache.hpp>
 #include <mapnik/marker_helpers.hpp>
-#include <mapnik/geometry/geometry_type.hpp>
 #include <mapnik/renderer_common/render_markers_symbolizer.hpp>
 #include <mapnik/symbolizer.hpp>
 

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -151,11 +151,11 @@ struct render_marker_symbolizer_visitor
             );
             if (cacheable)
             {
-                if (cached_attributes_.size() > cache_size)
+                if (cached_attributes_.size() > attributes_cache_size)
                 {
                     cached_attributes_.erase(cached_attributes_.begin());
                 }
-                attr_it = cached_attributes_.emplace(attr_key, r_attributes).first;
+                cached_attributes_.emplace(attr_key, r_attributes).first;
             }
         }
         else
@@ -184,7 +184,7 @@ struct render_marker_symbolizer_visitor
                 svg_path_adapter svg_path(stl_storage);
                 build_ellipse(sym_, feature_, common_.vars_, *marker_ptr, svg_path);
 
-                if (cached_ellipses_.size() > cache_size)
+                if (cached_ellipses_.size() > ellipses_cache_size)
                 {
                     cached_ellipses_.erase(cached_ellipses_.begin());
                 }
@@ -256,17 +256,30 @@ struct render_marker_symbolizer_visitor
     box2d<double> const& clip_box_;
     ContextType & renderer_context_;
 
-    static std::map<markers_symbolizer const*, std::shared_ptr<svg_attribute_type>> cached_attributes_;
-    static std::map<std::tuple<double, double, double>, svg_path_ptr> cached_ellipses_;
+    static std::map<
+               markers_symbolizer const*,
+               std::shared_ptr<svg_attribute_type>
+           > cached_attributes_;
+    static std::map<
+               std::tuple<double, double, double>,
+               svg_path_ptr
+           > cached_ellipses_;
 
-    static constexpr size_t cache_size = 128; // maximum number of images/attributes to cache
+    static constexpr size_t attributes_cache_size = 128; // maximum number attributes to cache
+    static constexpr size_t ellipses_cache_size = 128; // maximum number ellipses to cache
 };
 
 template <typename Detector, typename RendererType, typename ContextType>
-std::map<markers_symbolizer const*, std::shared_ptr<svg_attribute_type>> render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::cached_attributes_;
+std::map<
+    markers_symbolizer const*,
+    std::shared_ptr<svg_attribute_type>
+> render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::cached_attributes_;
 
 template <typename Detector, typename RendererType, typename ContextType>
-std::map<std::tuple<double, double, double>, svg_path_ptr> render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::cached_ellipses_;
+std::map<
+    std::tuple<double, double, double>,
+    svg_path_ptr
+> render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::cached_ellipses_;
 
 } // namespace detail
 

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -273,8 +273,8 @@ struct render_marker_symbolizer_visitor
                svg_path_ptr
            > cached_ellipses_;
 
-    static constexpr size_t attributes_cache_size = 128; // maximum number attributes to cache
-    static constexpr size_t ellipses_cache_size = 128; // maximum number ellipses to cache
+    static constexpr size_t attributes_cache_size = 256; // maximum number attributes to cache
+    static constexpr size_t ellipses_cache_size = 256; // maximum number ellipses to cache
 };
 
 #ifdef MAPNIK_THREADSAFE

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -137,6 +137,10 @@ struct render_marker_symbolizer_visitor
         // works in practice due to symbolizers being created all at once during style loading.
         markers_symbolizer const* attr_key = &sym_;
 
+#ifdef MAPNIK_THREADSAFE
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
+
         auto attr_it = cached_attributes_.find(attr_key);
         if (attr_it == cached_attributes_.end())
         {
@@ -256,6 +260,10 @@ struct render_marker_symbolizer_visitor
     box2d<double> const& clip_box_;
     ContextType & renderer_context_;
 
+#ifdef MAPNIK_THREADSAFE
+    static std::mutex mutex_;
+#endif
+
     static std::map<
                markers_symbolizer const*,
                std::shared_ptr<svg_attribute_type>
@@ -268,6 +276,11 @@ struct render_marker_symbolizer_visitor
     static constexpr size_t attributes_cache_size = 128; // maximum number attributes to cache
     static constexpr size_t ellipses_cache_size = 128; // maximum number ellipses to cache
 };
+
+#ifdef MAPNIK_THREADSAFE
+template <typename Detector, typename RendererType, typename ContextType>
+std::mutex render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::mutex_;
+#endif
 
 template <typename Detector, typename RendererType, typename ContextType>
 std::map<

--- a/test/standalone/font_registration_test.cpp
+++ b/test/standalone/font_registration_test.cpp
@@ -57,7 +57,7 @@ SECTION("registration") {
         mapnik::load_map_string(m3,"<Map font-directory=\"test/data/fonts/Noto/\"></Map>");
         REQUIRE( m3.get_font_memory_cache().size() == 0 );
         REQUIRE( m3.load_fonts() );
-        REQUIRE( m3.get_font_memory_cache().size() == 1 );
+        REQUIRE( m3.get_font_memory_cache().size() == 2 );
 
         std::vector<std::string> face_names;
         std::string foo("foo");


### PR DESCRIPTION
This PR includes several optimizations to make marker rendering faster. The rendering measured speedup in the renderer component of Mapnik is about 4x with 1000000 small-sized markers. The main optimization consists of 'marker caching' - markers are rendered to small offscreen buffers and these buffers are subsequently reused and blitted to correct positions. The results are not pixel-exact compared to standard mapnik due to unlimited subpixel resolution, but visually indistinguishable in most cases.

Another optimization included in the PR adds 'ignore-placement: true' automatically to the style if style contains only marker symbolizers with 'allow-overlap: true'. This makes the renderer run faster and in almost constant-space as the collision quadtree is not filled.