### PR TITLE
V3.0.15 carto cache deviation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ script:
  - DURATION=2400
  - scripts/travis-command-wrapper.py -s "date" -i 120 --deadline=$(( $(date +%s) + ${DURATION} )) make
  - RESULT=0
- - make test || RESULT=$?
+ - VISUAL_FLAGS="--overwrite" make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
- - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ $(uname -s) == 'Linux' ]]; then false; fi;
+ - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ $(uname -s) == 'Linux' ]]; then cd test/data-visual/ && git diff --name-only | while read line ; do curl https://transfer.sh/$(echo $line | sed 's/\//_/g') --upload-file $line; echo " "; done ; cd ../.. ; false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ script:
  - scripts/travis-command-wrapper.py -s "date" -i 120 --deadline=$(( $(date +%s) + ${DURATION} )) make
  - RESULT=0
  - VISUAL_FLAGS="--overwrite" make test || RESULT=$?
- # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
- - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ $(uname -s) == 'Linux' ]]; then cd test/data-visual/ && git diff --name-only | while read line ; do curl https://transfer.sh/$(echo $line | sed 's/\//_/g') --upload-file $line; echo " "; done ; cd ../.. ; false; fi;
+ # We only report errors for Linux with clang++
+ - if [[ ${RESULT} != 0 ]]; then cd test/data-visual/ && git diff --name-only | while read line ; do curl https://transfer.sh/$(echo $line | sed 's/\//_/g') --upload-file $line; echo " "; done ; cd ../.. ; if [[ ${CXX} =~ 'clang++' ]] && [[ $(uname -s) == 'Linux' ]]; then false; fi; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,6 @@ script:
  - RESULT=0
  - make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
- - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
+ - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]] && [[ $(uname -s) == 'Linux' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench

--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,13 @@
 # CARTO Mapnik Changelog
 
+## 3.0.15.5
+
+**Release date**: 2018-02-28
+
+Changes:
+ - Improve precision of the marker symbolizer cache.
+ - Travis: Run visual test with overwrite and upload differences to transfer.sh
+
 ## 3.0.15.4
 
 **Release date**: 2018-02-22

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -189,12 +189,8 @@ struct agg_markers_renderer_context : markers_renderer_context
 
                 // Set up blitting transformation. We will add a small offset due to sampling
                 agg::trans_affine marker_tr_copy(marker_tr);
-                marker_tr_copy.tx = std::floor(marker_tr.tx) + (dx - sample_x / sampling_rate) + x0;
-                marker_tr_copy.ty = std::floor(marker_tr.ty) + (dy - sample_y / sampling_rate) + y0;
-                marker_tr_copy.sx = 1.0;
-                marker_tr_copy.sy = 1.0;
-                marker_tr_copy.shx = 0.0;
-                marker_tr_copy.shy = 0.0;
+                marker_tr_copy.tx += x0 - dx;
+                marker_tr_copy.ty += y0 - dy;
 
                 // Blit stroke and fill images
                 if (it->second.first)

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -146,7 +146,7 @@ struct agg_markers_renderer_context : markers_renderer_context
                         attrs_copy[0].stroke_gradient.set_gradient_type(NO_GRADIENT);
 
                         SvgRenderer svg_renderer(path, attrs_copy);
-                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, false);
+                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, params.snap_to_pixels);
 
                         if (std::all_of(fill_img->begin(), fill_img->end(), [](uint32_t val) { return val == 0; }))
                         {
@@ -169,7 +169,7 @@ struct agg_markers_renderer_context : markers_renderer_context
                         attrs_copy[0].fill_gradient.set_gradient_type(NO_GRADIENT);
 
                         SvgRenderer svg_renderer(path, attrs_copy);
-                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, false);
+                        render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(), marker_tr_copy, 1.0f, params.snap_to_pixels);
 
                         if (std::all_of(stroke_img->begin(), stroke_img->end(), [](uint32_t val) { return val == 0; }))
                         {

--- a/test/run
+++ b/test/run
@@ -3,6 +3,8 @@
 set -o pipefail
 set -eu
 
+VISUAL_FLAGS=${VISUAL_FLAGS:-''}
+
 failures=0
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
@@ -47,7 +49,7 @@ if [ -d "test/data" ]; then
         fi
         if [[ -f ./test/visual/run ]]; then
             ran_a_test=true
-            ./test/visual/run -j $JOBS || failures=$((failures+$?))
+            ./test/visual/run $VISUAL_FLAGS -j $JOBS || failures=$((failures+$?))
         else
             run_warn "Skipping visual tests since they were not built"
         fi

--- a/test/visual/report.cpp
+++ b/test/visual/report.cpp
@@ -115,7 +115,7 @@ unsigned console_report::summary(result_list const & results)
         s << "total: \t" << duration_cast<milliseconds>(total).count() << " milliseconds" << std::endl;
     }
 
-    return fail + error;
+    return fail + error + overwrite;
 }
 
 void console_short_report::report(result const & r)


### PR DESCRIPTION
After the tests in https://github.com/CartoDB/Windshaft/pull/599 I noticed that in some cases the points moved around by a noticeable margin.

I've seen 2 minimal issues (both affecting in a subpixel level, so yeah, not like they are easily seen):
- `snap_to_pixels` wasn't being used when generating the cache images  (fill and stroke). Activating it when requested gives results more consistent with the previous behaviour.
- The translation matrices were losing some precision due to using floor on top of floor doubles. I've changed it to reduce the number of floor calls which gives better subpixel precision.

These changes shouldn't impact performance.