### PR TITLE
Fix build issue with MAPNIK_THREADSAFE disabled 

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -5,7 +5,8 @@
 **Release date**: 2018-XX-XX
 
 Changes:
- - Metrics: Compatibily fix for older compilers (80ecf2741 by @dprophet).
+ - Metrics: Compatibily fix for older compilers (80ecf2741 by @dprophet)
+ - Fix build issue with MAPNIK_THREADSAFE disabled 
 
 ## 3.0.15.6
 

--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -32,6 +32,8 @@
 
 #include <gdal_version.h>
 
+#include <mutex>
+
 using mapnik::datasource;
 using mapnik::parameters;
 

--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -41,6 +41,7 @@
 
 // stl
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 


### PR DESCRIPTION
I'll start bringing atomic fixes from my super branch:
This is just a couple of needed includes so it builds when `MAPNIK_THREADSAFE` is disabled. Required by std::once_flag.