### PR TITLE
Metrics rework

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -8,6 +8,7 @@ Changes:
  - Metrics: Compatibily fix for older compilers (80ecf2741 by @dprophet)
  - Fix build issue with MAPNIK_THREADSAFE disabled
  - Metrics: Internal rework (no mutex, no tree) to improve performance
+ - Metrics: Add metrics for feature types
 
 ## 3.0.15.6
 

--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -6,7 +6,8 @@
 
 Changes:
  - Metrics: Compatibily fix for older compilers (80ecf2741 by @dprophet)
- - Fix build issue with MAPNIK_THREADSAFE disabled 
+ - Fix build issue with MAPNIK_THREADSAFE disabled
+ - Metrics: Internal rework (no mutex, no tree) to improve performance
 
 ## 3.0.15.6
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,30 +12,51 @@ Capturing metrics is enabled during the configuration step:
 
 ### Mapnik
 
-The metrics object is defined in `mapnik/metrics.hpp` and it's designed to be shared between objects. Currently the metrics are being added in `include/mapnik/feature_style_processor_impl.hpp` which shares them, via composition with `grid_renderer` and `agg_renderer` which share them with the `grid` and `image` classes.
+The metrics object is defined in `mapnik/metrics.hpp` and it's designed to be shared between objects but beware that it doesn't have any internal synchronization, so if you want to share it between threads you'll need to use some external synchronization method.
 
-The metrics are added in a tree by the name, using `.` as separators. For example:
+Currently the metrics are being added in `include/mapnik/feature_style_processor_impl.hpp` which shares them, via composition with `agg_renderer`, `grid_renderer` and  which share them with the `grid` and `image` classes.
+
+The metrics are stored in a vector for fast access and they differ by its `name_` only. For performance reasons the internal comparison (to add new measurements) is done by comparing the pointer itself (`char *`) and, since it doesn't store a copy of the name the string has to outlive the metric, so using a `static char*` is recommended.
+
+The metrics are output in a tree under the `Mapnik` property:
 ```json
 {
    "Mapnik":{
-      "Time (us)":7229,
-      "Calls":1,
+      "Datasource":{
+         "Time (us)":10897,
+         "Calls":2
+      },
       "Setup":{
-         "Time (us)":2256,
-         "Calls":1,
-         "Datasource: Get Feature":{
-            "Time (us)":2231,
-            "Calls":1
-         }
+         "Time (us)":10920,
+         "Calls":2
+      },
+      "Agg_PPolygonS":{
+         "Time (us)":10,
+         "Calls":2
+      },
+      "Features_cnt_Polygon":4,
+      "Render_Style":{
+         "Time (us)":3650,
+         "Calls":4
+      },
+      "Agg_PLineS":{
+         "Time (us)":10,
+         "Calls":2
       },
       "Render":{
-         "Time (us)":4886,
-         "Calls":1,
-         "Style":{
-            "Time (us)":4883,
-            "Calls":1,
-            "features":284
-         }
+         "Time (us)":3831,
+         "Calls":2
+      },
+      "Agg_PMS_AttrCache_Miss":1,
+      "Agg_PMS_ImageCache_Miss":41,
+      "Agg_PMarkerS":{
+         "Time (us)":3217,
+         "Calls":469
+      },
+      "Features_cnt_Point":938,
+      "All":{
+         "Time (us)":14830,
+         "Calls":1
       }
    }
 }
@@ -51,7 +72,7 @@ Returns  an unique_ptr to class that will automatically add the metric once it's
 ```c++
     for (int i = 0; i < 10; i++)
     {
-        METRIC_UNUSED auto t = metrics_.measure_time("Mapnik.Setup");
+        METRIC_UNUSED auto t = metrics_.measure_time("Setup");
         //do_stuff
     }
 ```
@@ -72,24 +93,20 @@ Will lead to something like this:
 This is designed to add a different metric or edit an existing one. It uses the `measure_add` function:
 
 ```c++
-    inline void measure_add(std::string const& name, int64_t value = 1,
-                            measurement_t type = measurement_t::VALUE)
+    void measure_add(const char* const name, int64_t value = 1,
+                     measurement_t type = measurement_t::VALUE)
 ```
   The `value` parameter will be added (or substracted if negative) to the value of the metric. The `measurement_t` type is used only for new metrics with `TIME_MICROSECONDS` returning "Time (us)" and `VALUE` returning the name of the metric as a final leaf.
 
 Example:
 ```c++
-    metrics_.measure_add("Mapnik.Render.Style.features", features_count);
+    metrics_.measure_add("Features_cnt_Point", features_count);
 ```
 
 ```json
 {
    "Mapnik":{
-      "Render":{
-         "Style":{
-            "features":284
-         }
-      }
+      "Features_cnt_Point":938
    }
 }
 ```

--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -35,6 +35,8 @@
 #include <mapnik/expression_evaluator.hpp>
 #include <mapnik/feature.hpp>
 #include <mapnik/feature_type_style.hpp>
+#include <mapnik/geometry_type.hpp>
+#include <mapnik/geometry_types.hpp>
 #include <mapnik/layer.hpp>
 #include <mapnik/map.hpp>
 #include <mapnik/projection.hpp>
@@ -56,6 +58,12 @@
 
 namespace mapnik
 {
+
+static const char* METRICS_NAME_ALL = "All";
+static const char* METRICS_NAME_SETUP = "Setup";
+static const char* METRICS_NAME_DATASOURCE = "Datasource";
+static const char* METRICS_NAME_RENDER = "Render";
+static const char* METRICS_NAME_RENDER_STYLE = "Render_Style";
 
 // Store material for layer rendering in a two step process
 struct layer_rendering_material
@@ -104,7 +112,7 @@ feature_style_processor<Processor>::feature_style_processor(Map const& m,
 template <typename Processor>
 void feature_style_processor<Processor>::apply(double scale_denom)
 {
-    METRIC_UNUSED auto t = metrics_.measure_time("Mapnik");
+    METRIC_UNUSED auto t = metrics_.measure_time(METRICS_NAME_ALL);
     Processor & p = static_cast<Processor&>(*this);
     p.start_map_processing(m_);
 
@@ -167,7 +175,7 @@ void feature_style_processor<Processor>::apply(mapnik::layer const& lyr,
                                                std::set<std::string>& names,
                                                double scale_denom)
 {
-    METRIC_UNUSED auto t = metrics_.measure_time("Mapnik");
+    METRIC_UNUSED auto t = metrics_.measure_time(METRICS_NAME_ALL);
     Processor & p = static_cast<Processor&>(*this);
     p.start_map_processing(m_);
     projection proj(m_.srs(),true);
@@ -238,7 +246,7 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material 
                                                        int buffer_size,
                                                        std::set<std::string>& names)
 {
-    METRIC_UNUSED auto t = metrics_.measure_time("Mapnik.Setup");
+    METRIC_UNUSED auto t = metrics_.measure_time(METRICS_NAME_SETUP);
     layer const& lay = mat.lay_;
 
     std::vector<std::string> const& style_names = lay.styles();
@@ -450,14 +458,14 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material 
     std::vector<featureset_ptr> & featureset_ptr_list = mat.featureset_ptr_list_;
     if (!group_by.empty() || cache_features)
     {
-        METRIC_UNUSED auto t2 = metrics_.measure_time("Mapnik.Setup.Datasource: Get Features");
+        METRIC_UNUSED auto t2 = metrics_.measure_time(METRICS_NAME_DATASOURCE);
         featureset_ptr_list.push_back(ds->features_with_context(q,current_ctx));
     }
     else
     {
         for(std::size_t i = 0; i < active_styles.size(); ++i)
         {
-            METRIC_UNUSED auto t2 = metrics_.measure_time("Mapnik.Setup.Datasource: Get Features");
+            METRIC_UNUSED auto t2 = metrics_.measure_time(METRICS_NAME_DATASOURCE);
             featureset_ptr_list.push_back(ds->features_with_context(q,current_ctx));
         }
     }
@@ -468,7 +476,7 @@ template <typename Processor>
 void feature_style_processor<Processor>::render_material(layer_rendering_material const & mat,
                                                          Processor & p )
 {
-    METRIC_UNUSED auto t = metrics_.measure_time("Mapnik.Render");
+    METRIC_UNUSED auto t = metrics_.measure_time(METRICS_NAME_RENDER);
     std::vector<feature_type_style const*> const & active_styles = mat.active_styles_;
     std::vector<featureset_ptr> const & featureset_ptr_list = mat.featureset_ptr_list_;
     if (featureset_ptr_list.empty())
@@ -588,8 +596,7 @@ void feature_style_processor<Processor>::render_style(
     featureset_ptr features,
     proj_transform const& prj_trans)
 {
-    METRIC_UNUSED auto t = metrics_.measure_time("Mapnik.Render.Style");
-    uint features_count = 0;
+    METRIC_UNUSED auto t = metrics_.measure_time(METRICS_NAME_RENDER_STYLE);
     p.start_style_processing(*style);
     if (!features)
     {
@@ -601,7 +608,6 @@ void feature_style_processor<Processor>::render_style(
     bool was_painted = false;
     while ((feature = features->next()))
     {
-        features_count++;
         bool do_else = true;
         bool do_also = false;
         for (rule const* r : rc.get_if_rules() )
@@ -660,7 +666,6 @@ void feature_style_processor<Processor>::render_style(
             }
         }
     }
-    metrics_.measure_add("Mapnik.Render.Style.features", features_count);
 
     p.painted(p.painted() | was_painted);
     p.end_style_processing(*style);

--- a/include/mapnik/geometry_types.hpp
+++ b/include/mapnik/geometry_types.hpp
@@ -38,6 +38,7 @@ enum geometry_types : std::uint8_t
     MultiLineString = 5,
     MultiPolygon = 6,
     GeometryCollection = 7,
+    TOTAL_SIZE
 };
 
 }}

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -26,7 +26,7 @@
 
 #include <mapnik/make_unique.hpp>
 
-#include <boost/next_prior.hpp>
+#include <algorithm>
 #include <sstream>
 #include <utility>
 
@@ -40,15 +40,16 @@ const std::string measurement_str[TOTAL_ENUM_SIZE] =
     "Calls"
 };
 
-measurement::measurement(int64_t value, measurement_t type)
+measurement::measurement(const char* const name, int64_t value, measurement_t type)
     : value_(value),
-      type_(type)
+      type_(type),
+      name_(name)
 {
 }
 
-autochrono::autochrono(metrics* m, std::string name)
+autochrono::autochrono(metrics* m, const char* const name)
     : metrics_(m),
-      name_(std::move(name))
+      name_(name)
 {
     start_ = clock_.now();
 }
@@ -60,133 +61,112 @@ autochrono::~autochrono()
 }
 
 metrics::metrics(bool enabled)
-    : enabled_(enabled)
+    : storage_(new metrics_array),
+      enabled_(enabled)
 {
 }
 
-metrics::metrics(metrics const &m, std::string prefix)
-    : enabled_(m.enabled_),
-      prefix_(m.prefix_ + prefix),
-      storage_(m.storage_)
-#ifdef MAPNIK_THREADSAFE
-     ,lock_(m.lock_)
-#endif
+/* Copy constructor */
+metrics::metrics(metrics const &m)
 {
+    storage_ = m.storage_;
+    enabled_ = m.enabled_;
 }
 
 /* Move constructor */
 metrics::metrics(metrics const &&m)
 {
-    *this = m;
+    storage_ = m.storage_;
+    enabled_ = m.enabled_;
 }
 
 /* Copy assignment operator */
 metrics& metrics::operator=(metrics const& m)
 {
     enabled_ = m.enabled_;
-    prefix_ = m.prefix_;
     storage_ = m.storage_;
-    lock_ = m.lock_;
     return *this;
 }
 
 /* Move assignment operator */
 metrics& metrics::operator=(metrics&& m)
 {
-    return *this = m;
+    storage_ = m.storage_;
+    enabled_ = m.enabled_;
+    return *this;
 }
 
-std::unique_ptr<autochrono> metrics::measure_time_impl(const std::string& name)
+std::unique_ptr<autochrono> metrics::measure_time_impl(const char* const name)
 {
     return std::make_unique<autochrono>(this, name);
 }
 
-void metrics::measure_add_impl(std::string const& name, int64_t value, measurement_t type)
+void metrics::measure_add_impl(const char* const name, int64_t value, measurement_t type)
 {
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(*this->lock_);
-#endif
-    auto child = storage_->get_child_optional(prefix_ + name);
-    if (!child)
+    auto it = std::find_if(storage_->begin(), storage_->end(), [&](const measurement& m)
     {
-        storage_->put(prefix_ + name, measurement(value, type));
+        return (m.name_ == name);
+    });
+
+    if (it == storage_->end())
+    {
+        storage_->emplace_back(name, value, type);
     }
     else
     {
-        auto &measure = child->data();
-        measure.value_ += value;
-        if (measure.type_ == measurement_t::UNASSIGNED)
-        {
-            measure.type_ = type;
-        }
-        else
-        {
-            measure.calls_++;
-        }
+        it->value_ += value;
+        it->calls_++;
     }
 }
 
 
-boost::optional<measurement &> metrics::find(std::string const& name, bool ignore_prefix)
+boost::optional<measurement &> metrics::find(const char* const name)
 {
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(*this->lock_);
-#endif
-    auto m = storage_->get_child_optional(ignore_prefix ? name : prefix_ + name);
-    return (m ? m->data() : boost::optional<measurement &>());
-}
-
-/**
- * Recursively generate a JSON string from a metrics tree.
- * It doesn't use boost::property_tree::json_parser because we can have
- * nodes with data and children
- * @param buf
- * @param t
- */
-void to_string_helper(std::ostringstream &buf, metrics::metrics_tree t)
-{
-    measurement &m = t.data();
-    if (t.empty() && m.type_ == measurement_t::VALUE)
+    auto it = std::find_if(storage_->begin(), storage_->end(), [&](const measurement& m)
     {
-        buf << m.value_;
-        return;
-    }
+        return (m.name_ == name);
+    });
 
-    buf << "{";
-    if (m.type_ != measurement_t::UNASSIGNED)
-    {
-        buf << R"(")" << measurement_str[m.type_] << R"(":)" << m.value_;
-        if (m.type_ == measurement_t::TIME_MICROSECONDS)
-        {
-            buf << R"(,")" << measurement_str[measurement_t::CALLS];
-            buf << R"(":)" << m.calls_;
-        }
-        if (!t.empty())
-        {
-            buf << ",";
-        }
-    }
-
-    for (auto it = t.begin(); it != t.end(); it++)
-    {
-        buf << R"(")" << it->first << R"(":)";
-        to_string_helper(buf, it->second);
-        if (boost::next(it) != t.end())
-        {
-            buf << ",";
-        }
-    }
-    buf << "}";
+    return (it != storage_->end() ? *it : boost::optional<measurement &>());
 }
 
 std::string metrics::to_string()
 {
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(*this->lock_);
-#endif
     std::ostringstream buf;
 
-    to_string_helper(buf, *storage_);
+    buf << "{";
+    if (enabled_ && !storage_->empty())
+    {
+        buf << R"("Mapnik":{)";
+        for (auto it = storage_->begin(); it != storage_->end(); it++)
+        {
+            buf << R"(")" << it->name_ << R"(":)";
+            switch (it->type_)
+            {
+                case (measurement_t::VALUE):
+                    buf << it->value_;
+                    break;
+                case (measurement_t::TIME_MICROSECONDS):
+                    buf << "{";
+                    buf << R"(")" << measurement_str[measurement_t::TIME_MICROSECONDS];
+                    buf << R"(":)" << it->value_;
+                    buf << R"(,")" << measurement_str[measurement_t::CALLS];
+                    buf << R"(":)" << it->calls_;
+                    buf << "}";
+                    break;
+                default:
+                    break;
+            }
+
+            if (std::next(it) != storage_->end())
+            {
+                buf << ",";
+            }
+        }
+        buf << "}";
+    }
+
+    buf << "}";
     return buf.str();
 }
 


### PR DESCRIPTION
After I started adding more metrics deeper into the callstack I saw that the old  implementation wasn't good enough for fast operations so I changed some design decisions that makes them ~10x faster:
* Remove the mutex: since the metrics are used in a per map request and that's all done in a single thread it isn't needed. 
* Remove the tree structure and use an array instead. This was the big win since inserting was slow due to the structure chosen.
* Use `char *` and pointer comparison (so static strings) instead of std::string: faster search and inserts.