### PR TITLE
Metrics faster find

### DIFF
--- a/deps/agg/include/agg_color_rgba.h
+++ b/deps/agg/include/agg_color_rgba.h
@@ -611,14 +611,6 @@ struct rgba8T
     {
         return self_type(rgba::from_wavelength(wl, gamma));
     }
-
-    bool operator <(const self_type& o) const
-    {
-        if (r != o.r) return r < o.r;
-        if (g != o.g) return g < o.g;
-        if (b != o.b) return b < o.b;
-        return a < o.a;
-    }
 };
 
 typedef rgba8T<linear> rgba8;

--- a/deps/agg/include/agg_trans_affine.h
+++ b/deps/agg/include/agg_trans_affine.h
@@ -244,16 +244,6 @@ namespace agg
             return !is_equal(m, affine_epsilon);
         }
 
-        bool operator < (const trans_affine& m) const
-        {
-            if (sx != m.sx) return sx < m.sx;
-            if (shy != m.shy) return shy < m.shy;
-            if (shx != m.shx) return shx < m.shx;
-            if (sy != m.sy) return sy < m.sy;
-            if (tx != m.tx) return tx < m.tx;
-            return ty < m.ty;
-        }
-
         //-------------------------------------------- Transformations
         // Direct transformation of x and y
         void transform(double* x, double* y) const;

--- a/include/mapnik/cairo/cairo_render_vector.hpp
+++ b/include/mapnik/cairo/cairo_render_vector.hpp
@@ -26,6 +26,7 @@
 #define MAPNIK_CAIRO_RENDER_VECTOR_HPP
 
 // mapnik
+#include <mapnik/marker.hpp>
 #include <mapnik/svg/svg_path_adapter.hpp>
 
 namespace agg { struct trans_affine; }
@@ -38,7 +39,7 @@ template <typename T> class box2d;
 namespace svg { struct path_attributes; }
 
 void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          agg::pod_bvector<svg::path_attributes> const & attributes,
+                          svg_attribute_ptr attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity);
 

--- a/include/mapnik/gradient.hpp
+++ b/include/mapnik/gradient.hpp
@@ -95,8 +95,6 @@ public:
     void get_control_points(double &x1, double &y1, double &x2, double &y2, double &r) const;
     void get_control_points(double &x1, double &y1, double &x2, double &y2) const;
 
-    bool operator <(const gradient &b) const;
-
 private:
     void swap(gradient& other) noexcept;
 };

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -46,9 +46,9 @@ namespace svg { struct path_attributes; }
 using svg::svg_path_adapter;
 
 using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
+using svg_attribute_ptr = std::shared_ptr<agg::pod_bvector<svg::path_attributes>>;
 using svg_storage_type = svg::svg_storage<svg::svg_path_storage, svg_attribute_type>;
 using svg_path_ptr = std::shared_ptr<svg_storage_type>;
-using image_ptr = std::shared_ptr<image_any>;
 
 struct marker_rgba8
 {

--- a/include/mapnik/marker_helpers.hpp
+++ b/include/mapnik/marker_helpers.hpp
@@ -50,14 +50,13 @@ namespace mapnik {
 
 struct clip_poly_tag;
 
-using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
 
 template <typename Detector>
 struct vector_markers_dispatch : util::noncopyable
 {
     vector_markers_dispatch(svg_path_ptr const& src,
                             svg_path_adapter & path,
-                            svg_attribute_type const& attrs,
+                            svg_attribute_ptr attrs,
                             agg::trans_affine const& marker_trans,
                             symbolizer_base const& sym,
                             Detector & detector,
@@ -101,7 +100,7 @@ protected:
     markers_renderer_context & renderer_context_;
     svg_path_ptr const& src_;
     svg_path_adapter & path_;
-    svg_attribute_type const& attrs_;
+    svg_attribute_ptr attrs_;
     Detector & detector_;
 };
 

--- a/include/mapnik/renderer_common/render_markers_symbolizer.hpp
+++ b/include/mapnik/renderer_common/render_markers_symbolizer.hpp
@@ -62,7 +62,7 @@ struct markers_renderer_context : util::noncopyable
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_type const& attrs,
+                               svg_attribute_ptr attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr) = 0;
 

--- a/include/mapnik/renderer_common/render_thunk.hpp
+++ b/include/mapnik/renderer_common/render_thunk.hpp
@@ -44,14 +44,14 @@ namespace mapnik {
 struct vector_marker_render_thunk : util::movable
 {
     svg_path_ptr src_;
-    svg_attribute_type attrs_;
+    svg_attribute_ptr attrs_;
     agg::trans_affine tr_;
     double opacity_;
     composite_mode_e comp_op_;
     bool snap_to_pixels_;
 
     vector_marker_render_thunk(svg_path_ptr const& src,
-                               svg_attribute_type const& attrs,
+                               svg_attribute_ptr attrs,
                                agg::trans_affine const& marker_trans,
                                double opacity,
                                composite_mode_e comp_op,

--- a/include/mapnik/svg/svg_path_attributes.hpp
+++ b/include/mapnik/svg/svg_path_attributes.hpp
@@ -34,8 +34,6 @@
 #include "agg_trans_affine.h"
 #pragma GCC diagnostic pop
 
-#include <tuple> // needed for std::tie
-
 namespace mapnik {
 namespace svg {
 
@@ -139,61 +137,6 @@ struct path_attributes
           dash(attr.dash),
           dash_offset(attr.dash_offset)
     {}
-
-    bool operator <(const path_attributes &b) const
-    {
-        if (fill_color < b.fill_color) return true;
-        if (b.fill_color < fill_color) return false;
-
-        if (stroke_color < b.stroke_color) return true;
-        if (b.stroke_color < stroke_color) return false;
-
-        if (fill_gradient < b.fill_gradient) return true;
-        if (b.fill_gradient < fill_gradient) return false;
-
-        if (stroke_gradient < b.stroke_gradient) return true;
-        if (b.stroke_gradient < stroke_gradient) return false;
-
-        if (!transform.is_equal(b.transform)) return transform < b.transform;
-
-
-        return
-            std::tie(opacity,
-                     fill_opacity,
-                     stroke_opacity,
-                     miter_limit,
-                     stroke_width,
-                     index,
-                     line_join,
-                     line_cap,
-                     fill_flag,
-                     fill_none,
-                     stroke_flag,
-                     stroke_none,
-                     even_odd_flag,
-                     visibility_flag,
-                     display_flag,
-                     dash,
-                     dash_offset)
-            <
-            std::tie(b.opacity,
-                     b.fill_opacity,
-                     b.stroke_opacity,
-                     b.miter_limit,
-                     b.stroke_width,
-                     b.index,
-                     b.line_join,
-                     b.line_cap,
-                     b.fill_flag,
-                     b.fill_none,
-                     b.stroke_flag,
-                     b.stroke_none,
-                     b.even_odd_flag,
-                     b.visibility_flag,
-                     b.display_flag,
-                     b.dash,
-                     b.dash_offset);
-    }
 };
 
 }}

--- a/src/agg/process_group_symbolizer.cpp
+++ b/src/agg/process_group_symbolizer.cpp
@@ -86,7 +86,7 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
         renderer_base renb(pixf);
         svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(thunk.src_->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_type svg_renderer(svg_path, thunk.attrs_);
+        svg_renderer_type svg_renderer(svg_path, *thunk.attrs_);
 
         agg::trans_affine offset_tr = thunk.tr_;
         offset_tr.translate(offset_.x, offset_.y);

--- a/src/cairo/cairo_render_vector.cpp
+++ b/src/cairo/cairo_render_vector.cpp
@@ -33,16 +33,16 @@ namespace mapnik
 {
 
 void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          agg::pod_bvector<svg::path_attributes> const & attributes,
+                          svg_attribute_ptr attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity)
 {
     using namespace mapnik::svg;
     agg::trans_affine transform;
 
-    for(unsigned i = 0; i < attributes.size(); ++i)
+    for(unsigned i = 0; i < attributes->size(); ++i)
     {
-        mapnik::svg::path_attributes const& attr = attributes[i];
+        mapnik::svg::path_attributes const& attr = (*attributes)[i];
         if (!attr.visibility_flag)
             continue;
         cairo_save_restore guard(context);

--- a/src/cairo/cairo_renderer.cpp
+++ b/src/cairo/cairo_renderer.cpp
@@ -30,6 +30,7 @@
 #include <mapnik/cairo/cairo_render_vector.hpp>
 #include <mapnik/map.hpp>
 #include <mapnik/svg/svg_path_adapter.hpp>
+#include <mapnik/svg/svg_path_attributes.hpp>
 #include <mapnik/pixel_position.hpp>
 #include <mapnik/attribute.hpp>
 #include <mapnik/request.hpp>
@@ -254,7 +255,7 @@ struct cairo_render_marker_visitor
                 marker_tr *= tr_;
             }
             marker_tr *= agg::trans_affine_scaling(common_.scale_factor_);
-            agg::pod_bvector<svg::path_attributes> const & attributes = vmarker->attributes();
+            svg_attribute_ptr attributes = std::make_shared<svg_attribute_type>(vmarker->attributes());
             svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(vmarker->source());
             svg::svg_path_adapter svg_path(stl_storage);
             marker_tr.translate(pos_.x, pos_.y);

--- a/src/cairo/cairo_renderer.cpp
+++ b/src/cairo/cairo_renderer.cpp
@@ -255,7 +255,14 @@ struct cairo_render_marker_visitor
                 marker_tr *= tr_;
             }
             marker_tr *= agg::trans_affine_scaling(common_.scale_factor_);
-            svg_attribute_ptr attributes = std::make_shared<svg_attribute_type>(vmarker->attributes());
+
+            //Since the underlying type is a pod_array that creates a copy (memcpy) version
+            //of the attributes, using a copy here would mean that some underlying types
+            //using ref counts (e.g shared_ptr's) would have an extra reference but the
+            //count wouldn't be increased. This would mean that we'd try to free them an
+            //extra time. To avoid this we pass the raw pointer and remove the deleter
+            svg_attribute_ptr attributes(&vmarker->attributes(), [](svg_attribute_type*){});
+
             svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(vmarker->source());
             svg::svg_path_adapter svg_path(stl_storage);
             marker_tr.translate(pos_.x, pos_.y);

--- a/src/cairo/process_markers_symbolizer.cpp
+++ b/src/cairo/process_markers_symbolizer.cpp
@@ -41,7 +41,7 @@ struct cairo_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_type const& attrs,
+                               svg_attribute_ptr attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {

--- a/src/gradient.cpp
+++ b/src/gradient.cpp
@@ -23,8 +23,6 @@
 #include <mapnik/gradient.hpp>
 #include <mapnik/enumeration.hpp>
 
-#include <tuple> // needed for std::tie
-
 namespace mapnik
 {
 
@@ -155,22 +153,6 @@ void gradient::get_control_points(double &x1, double &y1, double &x2, double &y2
     y1 = y1_;
     x2 = x2_;
     y2 = y2_;
-}
-
-bool gradient::operator <(const gradient &b) const
-{
-    if (stops_.size() != b.stops_.size()) return stops_.size() < b.stops_.size();
-    for (size_t i = 0; i < stops_.size(); i++)
-    {
-        if (stops_[i].first != b.stops_[i].first) return stops_[i].first < b.stops_[i].first;
-        if (stops_[i].second.rgba() != b.stops_[i].second.rgba())
-            return stops_[i].second.rgba() < b.stops_[i].second.rgba();
-    }
-
-    if (!transform_.is_equal(b.transform_)) return transform_ < b.transform_;
-
-    return std::tie(x1_, y1_, x2_, y2_, r_, units_, gradient_type_)  <
-           std::tie(b.x1_, b.y1_, b.x2_, b.y2_, b.r_, b.units_,  b.gradient_type_);
 }
 
 }

--- a/src/grid/process_group_symbolizer.cpp
+++ b/src/grid/process_group_symbolizer.cpp
@@ -87,7 +87,7 @@ struct thunk_renderer : render_thunk_list_dispatch
         renderer_type ren(renb);
         vertex_stl_adapter<svg_path_storage> stl_storage(thunk.src_->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_type svg_renderer(svg_path, thunk.attrs_);
+        svg_renderer_type svg_renderer(svg_path, *thunk.attrs_);
         agg::trans_affine offset_tr = thunk.tr_;
         offset_tr.translate(offset_.x, offset_.y);
         //render_vector_marker(svg_renderer, *ras_ptr_, renb, thunk.src_->bounding_box(), offset_tr, thunk.opacity_, thunk.snap_to_pixels_);

--- a/src/grid/process_markers_symbolizer.cpp
+++ b/src/grid/process_markers_symbolizer.cpp
@@ -92,11 +92,11 @@ struct grid_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_type const& attrs,
+                               svg_attribute_ptr attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
-        SvgRenderer svg_renderer_(path, attrs);
+        SvgRenderer svg_renderer_(path, *attrs);
         agg::scanline_bin sl_;
         svg_renderer_.render_id(ras_, sl_, renb_, feature_.id(), marker_tr,
                                 params.opacity, src->bounding_box());

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -130,7 +130,7 @@ struct render_marker_symbolizer_visitor
         boost::optional<svg_path_ptr> const& stock_vector_marker = mark.get_data();
         svg_path_ptr marker_ptr = *stock_vector_marker;
 
-        std::shared_ptr<svg_attribute_type> r_attributes;
+        svg_attribute_ptr r_attributes = nullptr;
 
         // Look up the feature/symbolizer attributes from the cache.
         // We are using raw symbolizer pointer as a cache key. As this
@@ -238,7 +238,7 @@ struct render_marker_symbolizer_visitor
 
         vector_dispatch_type rasterizer_dispatch(marker_ptr,
                                                  svg_path,
-                                                 *r_attributes,
+                                                 r_attributes,
                                                  image_tr,
                                                  sym_,
                                                  *common_.detector_,
@@ -291,7 +291,7 @@ struct render_marker_symbolizer_visitor
 
     static std::map<
                markers_symbolizer const*,
-               std::pair<std::shared_ptr<svg_attribute_type>, markers_symbolizer::cont_type>
+               std::pair<svg_attribute_ptr, markers_symbolizer::cont_type>
            > cached_attributes_;
     static std::map<
                std::tuple<double, double, double>,
@@ -310,7 +310,7 @@ std::mutex render_marker_symbolizer_visitor<Detector, RendererType, ContextType>
 template <typename Detector, typename RendererType, typename ContextType>
 std::map<
     markers_symbolizer const*,
-    std::pair<std::shared_ptr<svg_attribute_type>, markers_symbolizer::cont_type>
+    std::pair<svg_attribute_ptr, markers_symbolizer::cont_type>
 > render_marker_symbolizer_visitor<Detector, RendererType, ContextType>::cached_attributes_;
 
 template <typename Detector, typename RendererType, typename ContextType>

--- a/src/renderer_common/render_thunk_extractor.cpp
+++ b/src/renderer_common/render_thunk_extractor.cpp
@@ -51,7 +51,7 @@ struct thunk_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_type const& attrs,
+                               svg_attribute_ptr attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {


### PR DESCRIPTION
Before we were comparing all attributes (recursively) to look into the cache map which is quite expensive (took around the same amount of time as rendering the images in a 1M point tile). Since the `attributes` are also cached, I've changed the signatures to pass the pointer (std::shared_ptr<>) to those cache attributes and use that as part of the key instead.

Since the `operator <` functions are no longer needed I've removed them to reduce the changes with the upstream repo.