### PR TITLE
Cache metrics

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -11,6 +11,7 @@ Changes:
  - Metrics: Internal rework (no mutex, no tree) to improve performance
  - Metrics: Add metrics for feature types
  - Metrics: Add metrics to the agg renderer
+ - Metrics: Add metrics for cache misses
 
 ## 3.0.15.6
 

--- a/include/mapnik/renderer_common/render_markers_symbolizer.hpp
+++ b/include/mapnik/renderer_common/render_markers_symbolizer.hpp
@@ -52,6 +52,10 @@ struct markers_dispatch_params
 
 struct markers_renderer_context : util::noncopyable
 {
+    markers_renderer_context(metrics &m)
+        : metrics_(m)
+    {}
+
     virtual void render_marker(image_rgba8 const& src,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr) = 0;
@@ -61,6 +65,8 @@ struct markers_renderer_context : util::noncopyable
                                svg_attribute_type const& attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr) = 0;
+
+    metrics metrics_;
 };
 
 MAPNIK_DECL

--- a/include/mapnik/renderer_common/render_thunk_extractor.hpp
+++ b/include/mapnik/renderer_common/render_thunk_extractor.hpp
@@ -88,6 +88,7 @@ private:
     proj_transform const& prj_trans_;
     virtual_renderer_common & common_;
     box2d<double> clipping_extent_;
+    metrics metrics_ = metrics(false);
 
     void update_box() const;
 };

--- a/src/cairo/process_markers_symbolizer.cpp
+++ b/src/cairo/process_markers_symbolizer.cpp
@@ -35,8 +35,8 @@ namespace detail {
 
 struct cairo_markers_renderer_context : markers_renderer_context
 {
-    explicit cairo_markers_renderer_context(cairo_context & ctx)
-      : ctx_(ctx)
+    explicit cairo_markers_renderer_context(cairo_context & ctx, metrics & m)
+      : markers_renderer_context(m), ctx_(ctx)
     {}
 
     virtual void render_marker(svg_path_ptr const& src,
@@ -77,7 +77,7 @@ void cairo_renderer<T>::process(markers_symbolizer const& sym,
     box2d<double> clip_box = common_.query_extent_;
 
     using context_type = detail::cairo_markers_renderer_context;
-    context_type renderer_context(context_);
+    context_type renderer_context(context_, this->metrics_);
 
     render_markers_symbolizer(
         sym, feature, prj_trans, common_, clip_box,

--- a/src/grid/process_markers_symbolizer.cpp
+++ b/src/grid/process_markers_symbolizer.cpp
@@ -78,8 +78,10 @@ struct grid_markers_renderer_context : markers_renderer_context
     grid_markers_renderer_context(feature_impl const& feature,
                                   BufferType & buf,
                                   RasterizerType & ras,
-                                  PixMapType & pixmap)
-      : feature_(feature),
+                                  PixMapType & pixmap,
+                                  metrics & m)
+      : markers_renderer_context(m),
+        feature_(feature),
         buf_(buf),
         pixf_(buf_),
         renb_(pixf_),
@@ -158,7 +160,7 @@ void grid_renderer<T>::process(markers_symbolizer const& sym,
                                                                buf_type,
                                                                grid_rasterizer,
                                                                buffer_type>;
-    context_type renderer_context(feature, render_buf, *ras_ptr, pixmap_);
+    context_type renderer_context(feature, render_buf, *ras_ptr, pixmap_, this->metrics_);
 
     render_markers_symbolizer(
         sym, feature, prj_trans, common_, clip_box, renderer_context);

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -153,6 +153,7 @@ struct render_marker_symbolizer_visitor
 
         if (!r_attributes)
         {
+            renderer_context_.metrics_.measure_add("Agg_PMS_AttrCache_Miss");
             svg_attribute_type s_attributes;
             r_attributes = std::make_shared<svg_attribute_type>(get_marker_attributes(*stock_vector_marker, s_attributes));
 
@@ -209,6 +210,7 @@ struct render_marker_symbolizer_visitor
 
             if (!marker_ptr)
             {
+                renderer_context_.metrics_.measure_add("Agg_PMS_EllipseCache_Miss");
                 marker_ptr = std::make_shared<svg_storage_type>();
                 vertex_stl_adapter<svg_path_storage> stl_storage(marker_ptr->source());
                 svg_path_adapter svg_path(stl_storage);

--- a/src/renderer_common/render_thunk_extractor.cpp
+++ b/src/renderer_common/render_thunk_extractor.cpp
@@ -42,8 +42,10 @@ struct thunk_markers_renderer_context : markers_renderer_context
     thunk_markers_renderer_context(symbolizer_base const& sym,
                                    feature_impl const& feature,
                                    attributes const& vars,
-                                   render_thunk_list & thunks)
-        : comp_op_(get<composite_mode_e, keys::comp_op>(sym, feature, vars))
+                                   render_thunk_list & thunks,
+                                   metrics & m)
+        : markers_renderer_context(m)
+        , comp_op_(get<composite_mode_e, keys::comp_op>(sym, feature, vars))
         , thunks_(thunks)
     {}
 
@@ -88,7 +90,7 @@ render_thunk_extractor::render_thunk_extractor(box2d<double> & box,
 void render_thunk_extractor::operator()(markers_symbolizer const& sym) const
 {
     using context_type = detail::thunk_markers_renderer_context;
-    context_type renderer_context(sym, feature_, vars_, thunks_);
+    context_type renderer_context(sym, feature_, vars_, thunks_, const_cast<metrics &>(this->metrics_));
 
     render_markers_symbolizer(
             sym, feature_, prj_trans_, common_, clipping_extent_, renderer_context);


### PR DESCRIPTION
Adds metrics to the `markers_renderer_context` struct and measures cache misses. 