### PR TITLE
Cache move

### DIFF
--- a/include/mapnik/cairo/cairo_render_vector.hpp
+++ b/include/mapnik/cairo/cairo_render_vector.hpp
@@ -39,7 +39,7 @@ template <typename T> class box2d;
 namespace svg { struct path_attributes; }
 
 void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          svg_attribute_ptr attributes,
+                          svg_attribute_type const& attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity);
 

--- a/include/mapnik/image.hpp
+++ b/include/mapnik/image.hpp
@@ -81,7 +81,7 @@ private:
     double scaling_;
     bool premultiplied_alpha_;
     bool painted_;
-public:METRIC_UNUSED
+public:
     metrics metrics_ = metrics(false);
 
     image();

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -36,6 +36,7 @@
 
 // stl
 #include <memory>
+#include <vector>
 
 namespace mapnik
 {
@@ -45,8 +46,7 @@ namespace svg { struct path_attributes; }
 
 using svg::svg_path_adapter;
 
-using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
-using svg_attribute_ptr = std::shared_ptr<agg::pod_bvector<svg::path_attributes>>;
+using svg_attribute_type = std::vector<svg::path_attributes>;
 using svg_storage_type = svg::svg_storage<svg::svg_path_storage, svg_attribute_type>;
 using svg_path_ptr = std::shared_ptr<svg_storage_type>;
 

--- a/include/mapnik/marker_helpers.hpp
+++ b/include/mapnik/marker_helpers.hpp
@@ -50,13 +50,12 @@ namespace mapnik {
 
 struct clip_poly_tag;
 
-
 template <typename Detector>
 struct vector_markers_dispatch : util::noncopyable
 {
     vector_markers_dispatch(svg_path_ptr const& src,
                             svg_path_adapter & path,
-                            svg_attribute_ptr attrs,
+                            svg_attribute_type & attrs,
                             agg::trans_affine const& marker_trans,
                             symbolizer_base const& sym,
                             Detector & detector,
@@ -100,7 +99,7 @@ protected:
     markers_renderer_context & renderer_context_;
     svg_path_ptr const& src_;
     svg_path_adapter & path_;
-    svg_attribute_ptr attrs_;
+    svg_attribute_type & attrs_;
     Detector & detector_;
 };
 

--- a/include/mapnik/renderer_common/render_markers_symbolizer.hpp
+++ b/include/mapnik/renderer_common/render_markers_symbolizer.hpp
@@ -63,7 +63,7 @@ struct markers_renderer_context : util::noncopyable
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_ptr attrs,
+                               svg_attribute_type & attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr) = 0;
 

--- a/include/mapnik/renderer_common/render_thunk.hpp
+++ b/include/mapnik/renderer_common/render_thunk.hpp
@@ -44,14 +44,14 @@ namespace mapnik {
 struct vector_marker_render_thunk : util::movable
 {
     svg_path_ptr src_;
-    svg_attribute_ptr attrs_;
+    svg_attribute_type & attrs_;
     agg::trans_affine tr_;
     double opacity_;
     composite_mode_e comp_op_;
     bool snap_to_pixels_;
 
     vector_marker_render_thunk(svg_path_ptr const& src,
-                               svg_attribute_ptr attrs,
+                               svg_attribute_type & attrs,
                                agg::trans_affine const& marker_trans,
                                double opacity,
                                composite_mode_e comp_op,

--- a/include/mapnik/svg/svg_converter.hpp
+++ b/include/mapnik/svg/svg_converter.hpp
@@ -24,6 +24,7 @@
 #define MAPNIK_SVG_CONVERTER_HPP
 
 // mapnik
+#include <mapnik/marker.hpp>
 #include <mapnik/svg/svg_path_attributes.hpp>
 #include <mapnik/svg/svg_path_adapter.hpp>
 #include <mapnik/util/noncopyable.hpp>
@@ -61,7 +62,7 @@ public:
     void begin_path()
     {
         std::size_t idx = source_.start_new_path();
-        attributes_.add(path_attributes(cur_attr(), safe_cast<unsigned>(idx)));
+        attributes_.push_back(path_attributes(cur_attr(), safe_cast<unsigned>(idx)));
     }
 
     void end_path()
@@ -70,7 +71,7 @@ public:
         {
             throw std::runtime_error("end_path : The path was not begun");
         }
-        path_attributes& attr = attributes_[attributes_.size() - 1];
+        path_attributes& attr = attributes_.back();
         unsigned idx = attr.index;
         attr = cur_attr();
         attr.index = idx;
@@ -172,7 +173,6 @@ public:
         else
         {
             source_.arc_to(rx, ry, angle, large_arc_flag, sweep_flag, x, y);
-
         }
     }
 
@@ -183,9 +183,9 @@ public:
 
     void push_attr()
     {
-        attr_stack_.add(attr_stack_.size() ?
-                        attr_stack_[attr_stack_.size() - 1] :
-                        path_attributes());
+        attr_stack_.push_back(attr_stack_.size() ?
+                              attr_stack_.back() :
+                              path_attributes());
     }
     void pop_attr()
     {
@@ -193,7 +193,7 @@ public:
         {
             throw std::runtime_error("pop_attr : Attribute stack is empty");
         }
-        attr_stack_.remove_last();
+        attr_stack_.pop_back();
     }
 
     // Attribute setting functions.
@@ -356,7 +356,7 @@ public:
         {
             throw std::runtime_error("cur_attr : Attribute stack is empty");
         }
-        return attr_stack_[attr_stack_.size() - 1];
+        return attr_stack_.back();
     }
 
 private:
@@ -370,7 +370,7 @@ private:
 };
 
 
-using svg_converter_type = svg_converter<svg_path_adapter,agg::pod_bvector<mapnik::svg::path_attributes> >;
+using svg_converter_type = svg_converter<svg_path_adapter,svg_attribute_type>;
 
 }}
 

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -34,6 +34,7 @@
 #include <mapnik/attribute.hpp>
 #include <mapnik/text/font_feature_settings.hpp>
 #include <mapnik/util/variant.hpp>
+#include <mapnik/marker.hpp>
 
 // stl
 #include <memory>
@@ -139,7 +140,16 @@ struct MAPNIK_DECL text_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL shield_symbolizer : public text_symbolizer {};
 struct MAPNIK_DECL line_pattern_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL polygon_pattern_symbolizer : public symbolizer_base {};
-struct MAPNIK_DECL markers_symbolizer : public symbolizer_base {};
+struct MAPNIK_DECL markers_symbolizer : public symbolizer_base {
+
+    std::shared_ptr<svg_attribute_type> cached_attributes = nullptr;
+#ifdef MAPNIK_THREADSAFE
+    std::shared_ptr<std::mutex> cache_mutex = std::shared_ptr<std::mutex>(new std::mutex());
+#endif
+    std::map<std::tuple<double, double, double>, svg_path_ptr> cached_ellipses;
+
+    static constexpr size_t ellipses_cache_size = 256; // maximum number ellipses to cache
+};
 struct MAPNIK_DECL raster_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL building_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL group_symbolizer : public symbolizer_base {};

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -140,16 +140,17 @@ struct MAPNIK_DECL text_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL shield_symbolizer : public text_symbolizer {};
 struct MAPNIK_DECL line_pattern_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL polygon_pattern_symbolizer : public symbolizer_base {};
-struct MAPNIK_DECL markers_symbolizer : public symbolizer_base {
+
+//Marker symbolizer with cached attributes
+struct MAPNIK_DECL markers_symbolizer : public symbolizer_base
+{
+    enum cache_status { UNCHECKED, UNCACHEABLE, CACHEABLE };
 
     std::shared_ptr<svg_attribute_type> cached_attributes = nullptr;
-#ifdef MAPNIK_THREADSAFE
-    std::shared_ptr<std::mutex> cache_mutex = std::shared_ptr<std::mutex>(new std::mutex());
-#endif
-    std::map<std::tuple<double, double, double>, svg_path_ptr> cached_ellipses;
-
-    static constexpr size_t ellipses_cache_size = 256; // maximum number ellipses to cache
+    svg_path_ptr cached_ellipse = nullptr;
+    cache_status cacheable = UNCHECKED;
 };
+
 struct MAPNIK_DECL raster_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL building_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL group_symbolizer : public symbolizer_base {};

--- a/src/agg/process_group_symbolizer.cpp
+++ b/src/agg/process_group_symbolizer.cpp
@@ -86,7 +86,7 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
         renderer_base renb(pixf);
         svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(thunk.src_->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_type svg_renderer(svg_path, *thunk.attrs_);
+        svg_renderer_type svg_renderer(svg_path, thunk.attrs_);
 
         agg::trans_affine offset_tr = thunk.tr_;
         offset_tr.translate(offset_.x, offset_.y);

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -59,7 +59,7 @@ struct agg_markers_renderer_context : markers_renderer_context
     using attribute_source_type = typename SvgRenderer::attribute_source_type;
     using pixfmt_type = typename renderer_base::pixfmt_type;
 
-    agg_markers_renderer_context(symbolizer_base const& sym,
+    agg_markers_renderer_context(markers_symbolizer const& sym,
                                  feature_impl const& feature,
                                  attributes const& vars,
                                  BufferType & buf,
@@ -111,7 +111,7 @@ struct agg_markers_renderer_context : markers_renderer_context
 
                 int sample_idx = static_cast<int>(sample_y) * sampling_rate + static_cast<int>(sample_x);
 
-                std::tuple<svg_path_ptr, int, svg_attribute_ptr> key(src, sample_idx, attrs);
+                std::pair<svg_attribute_ptr, int> key(attrs, sample_idx);
 
                 std::shared_ptr<image_rgba8> fill_img = nullptr;
                 std::shared_ptr<image_rgba8> stroke_img = nullptr;
@@ -252,7 +252,7 @@ private:
 #endif
 
     static std::map<
-		std::tuple<svg_path_ptr, int, svg_attribute_ptr>,
+		std::pair<svg_attribute_ptr, int>,
 		std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
 	    > cached_images_;
 
@@ -267,7 +267,7 @@ std::mutex agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>
 
 template <typename SvgRenderer, typename BufferType, typename RasterizerType>
 std::map<
-    std::tuple<svg_path_ptr, int, svg_attribute_ptr>,
+    std::pair<svg_attribute_ptr, int>,
     std::pair<std::shared_ptr<image_rgba8>, std::shared_ptr<image_rgba8>>
 > agg_markers_renderer_context<SvgRenderer, BufferType, RasterizerType>::cached_images_ = {};
 
@@ -310,8 +310,7 @@ void agg_renderer<T0,T1>::process(markers_symbolizer const& sym,
                                                                   buf_type,
                                                                   rasterizer>;
     agg_context_type renderer_context(sym, feature, common_.vars_, render_buffer, *ras_ptr, agg_renderer::metrics_, markers_symbolizer_caches_disabled_);
-    render_markers_symbolizer(
-        sym, feature, prj_trans, common_, clip_box, renderer_context);
+    render_markers_symbolizer(sym, feature, prj_trans, common_, clip_box, renderer_context);
 }
 
 template void agg_renderer<image_rgba8>::process(markers_symbolizer const&,

--- a/src/cairo/cairo_render_vector.cpp
+++ b/src/cairo/cairo_render_vector.cpp
@@ -33,16 +33,16 @@ namespace mapnik
 {
 
 void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          svg_attribute_ptr attributes,
+                          svg_attribute_type const& attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity)
 {
     using namespace mapnik::svg;
     agg::trans_affine transform;
 
-    for(unsigned i = 0; i < attributes->size(); ++i)
+    for(unsigned i = 0; i < attributes.size(); ++i)
     {
-        mapnik::svg::path_attributes const& attr = (*attributes)[i];
+        mapnik::svg::path_attributes const& attr = attributes[i];
         if (!attr.visibility_flag)
             continue;
         cairo_save_restore guard(context);

--- a/src/cairo/cairo_renderer.cpp
+++ b/src/cairo/cairo_renderer.cpp
@@ -255,14 +255,7 @@ struct cairo_render_marker_visitor
                 marker_tr *= tr_;
             }
             marker_tr *= agg::trans_affine_scaling(common_.scale_factor_);
-
-            //Since the underlying type is a pod_array that creates a copy (memcpy) version
-            //of the attributes, using a copy here would mean that some underlying types
-            //using ref counts (e.g shared_ptr's) would have an extra reference but the
-            //count wouldn't be increased. This would mean that we'd try to free them an
-            //extra time. To avoid this we pass the raw pointer and remove the deleter
-            svg_attribute_ptr attributes(&vmarker->attributes(), [](svg_attribute_type*){});
-
+            auto const& attributes = vmarker->attributes();
             svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(vmarker->source());
             svg::svg_path_adapter svg_path(stl_storage);
             marker_tr.translate(pos_.x, pos_.y);

--- a/src/cairo/process_markers_symbolizer.cpp
+++ b/src/cairo/process_markers_symbolizer.cpp
@@ -41,7 +41,7 @@ struct cairo_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_ptr attrs,
+                               svg_attribute_type & attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {

--- a/src/grid/grid_renderer.cpp
+++ b/src/grid/grid_renderer.cpp
@@ -176,10 +176,9 @@ struct grid_render_marker_visitor
         vertex_stl_adapter<svg_path_storage> stl_storage(marker.get_data()->source());
         svg_path_adapter svg_path(stl_storage);
         svg_renderer_agg<svg_path_adapter,
-            agg::pod_bvector<path_attributes>,
+            svg_attribute_type,
             renderer_type,
-            pixfmt_type> svg_renderer(svg_path,
-                                                marker.get_data()->attributes());
+            pixfmt_type> svg_renderer(svg_path, marker.get_data()->attributes());
 
         svg_renderer.render_id(*ras_ptr_, sl, renb, feature_.id(), mtx, opacity_, bbox);
     }

--- a/src/grid/process_group_symbolizer.cpp
+++ b/src/grid/process_group_symbolizer.cpp
@@ -86,7 +86,7 @@ struct thunk_renderer : render_thunk_list_dispatch
         scanline_renderer_type ren(renb);
         vertex_stl_adapter<svg_path_storage> stl_storage(thunk.src_->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_type svg_renderer(svg_path, *thunk.attrs_);
+        svg_renderer_type svg_renderer(svg_path, thunk.attrs_);
         agg::trans_affine offset_tr = thunk.tr_;
         offset_tr.translate(offset_.x, offset_.y);
         //render_vector_marker(svg_renderer, *ras_ptr_, renb, thunk.src_->bounding_box(), offset_tr, thunk.opacity_, thunk.snap_to_pixels_);

--- a/src/grid/process_markers_symbolizer.cpp
+++ b/src/grid/process_markers_symbolizer.cpp
@@ -92,11 +92,11 @@ struct grid_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_ptr attrs,
+                               svg_attribute_type & attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
-        SvgRenderer svg_renderer_(path, *attrs);
+        SvgRenderer svg_renderer_(path, attrs);
         agg::scanline_bin sl_;
         svg_renderer_.render_id(ras_, sl_, renb_, feature_.id(), marker_tr,
                                 params.opacity, src->bounding_box());

--- a/src/marker_helpers.cpp
+++ b/src/marker_helpers.cpp
@@ -94,7 +94,7 @@ bool push_explicit_style(svg_attribute_type const& src,
         for(unsigned i = 0; i < src.size(); ++i)
         {
             dst.push_back(src[i]);
-            mapnik::svg::path_attributes & attr = dst.last();
+            mapnik::svg::path_attributes & attr = dst.back();
             if (!attr.visibility_flag)
                 continue;
             success = true;

--- a/src/renderer_common/render_pattern.cpp
+++ b/src/renderer_common/render_pattern.cpp
@@ -65,7 +65,7 @@ void render_pattern<image_rgba8>(rasterizer & ras,
     mapnik::svg::vertex_stl_adapter<mapnik::svg::svg_path_storage> stl_storage(marker.get_data()->source());
     mapnik::svg::svg_path_adapter svg_path(stl_storage);
     mapnik::svg::svg_renderer_agg<mapnik::svg::svg_path_adapter,
-                                  agg::pod_bvector<mapnik::svg::path_attributes>,
+                                  svg_attribute_type,
                                   renderer_solid,
                                   pixfmt > svg_renderer(svg_path,
                                                         marker.get_data()->attributes());

--- a/src/renderer_common/render_thunk_extractor.cpp
+++ b/src/renderer_common/render_thunk_extractor.cpp
@@ -51,7 +51,7 @@ struct thunk_markers_renderer_context : markers_renderer_context
 
     virtual void render_marker(svg_path_ptr const& src,
                                svg_path_adapter & path,
-                               svg_attribute_ptr attrs,
+                               svg_attribute_type & attrs,
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -22,6 +22,7 @@
 
 #include <mapnik/debug.hpp>
 #include <mapnik/color_factory.hpp>
+#include <mapnik/marker.hpp>
 #include <mapnik/svg/svg_parser.hpp>
 #include <mapnik/svg/svg_path_parser.hpp>
 #include <mapnik/config_error.hpp>
@@ -1045,8 +1046,7 @@ void parse_linear_gradient(svg_parser & parser, rapidxml::xml_node<char> const* 
     parser.gradient_map_[parser.temporary_gradient_.first] = parser.temporary_gradient_.second;
 }
 
-svg_parser::svg_parser(svg_converter<svg_path_adapter,
-                       agg::pod_bvector<mapnik::svg::path_attributes> > & path)
+svg_parser::svg_parser(svg_converter<svg_path_adapter, svg_attribute_type > & path)
     : path_(path),
       is_defs_(false) {}
 

--- a/utils/svg2png/svg2png.cpp
+++ b/utils/svg2png/svg2png.cpp
@@ -96,7 +96,7 @@ struct main_marker_visitor
         mapnik::svg::vertex_stl_adapter<mapnik::svg::svg_path_storage> stl_storage(marker.get_data()->source());
         mapnik::svg::svg_path_adapter svg_path(stl_storage);
         mapnik::svg::svg_renderer_agg<mapnik::svg::svg_path_adapter,
-            agg::pod_bvector<mapnik::svg::path_attributes>,
+            mapnik::svg_attribute_type,
             renderer_solid,
             agg::pixfmt_rgba32_pre > svg_renderer_this(svg_path,
                                                        marker.get_data()->attributes());


### PR DESCRIPTION
A quick explanation of how this works:
A map instantiation has N symbolizers (1 for really simple maps), but it can have as many as you wish depending on the CartoCSS.
For the marker symbolizer, if it's cacheable (no expressions in its properties) you only have one set of attributes so you can [cache that](https://github.com/Algunenano/mapnik/blob/86a3ef72e8ef7abe6f50bd636afb650062d1209a/include/mapnik/symbolizer_base.hpp#L145).

Then, in the agg_renderer for each attribute you can have as many as sampling_rate * sampling_rate different images, so what I'm doing is storing them [as part of the attributes](https://github.com/Algunenano/mapnik/blob/86a3ef72e8ef7abe6f50bd636afb650062d1209a/include/mapnik/svg/svg_path_attributes.hpp#L65) which is less nice since the same attributes are used for different renderers that don't need that extra attribute there (so there is some extra overhead in memory).