### PR TITLE
Fix issues with clipping 

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,12 @@
 # CARTO Mapnik Changelog
 
+## 3.0.15.10
+**Release date**: 2018-XX-XX
+
+Changes:
+ - Improve clip calculation to avoid issues when using offset.
+
+
 ## 3.0.15.9
 **Release date**: 2018-05-14
 

--- a/include/mapnik/offset_converter.hpp
+++ b/include/mapnik/offset_converter.hpp
@@ -129,6 +129,14 @@ struct offset_converter
             //break; // uncomment this to see all the curls
 
             vertex2d const& u0 = vertices_[i];
+
+            // End or beginning of a line or ring must not be filtered out
+            // to not to join lines or rings together.
+            if (u0.cmd == SEG_CLOSE || u0.cmd == SEG_MOVETO)
+            {
+                break;
+            }
+
             vertex2d const& u1 = vertices_[i+1];
             double const dx = u0.x - cur_.x;
             double const dy = u0.y - cur_.y;

--- a/include/mapnik/offset_converter.hpp
+++ b/include/mapnik/offset_converter.hpp
@@ -40,6 +40,8 @@
 namespace mapnik
 {
 
+static constexpr double offset_converter_default_threshold = 5.0;
+
 template <typename Geometry>
 struct offset_converter
 {
@@ -48,7 +50,7 @@ struct offset_converter
     offset_converter(Geometry & geom)
         : geom_(geom)
         , offset_(0.0)
-        , threshold_(5.0)
+        , threshold_(offset_converter_default_threshold)
         , half_turn_segments_(16)
         , status_(initial)
         , pre_first_(vertex2d::no_init)

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -134,12 +134,11 @@ private:
         box2d<double> clip_box = clipping_extent(common_);
         if (clip)
         {
-            double padding = (double)(common_.query_extent_.width()/pixmap_.width());
-            if (half_stroke > 1)
-                padding *= half_stroke;
-            if (std::fabs(offset) > 0)
-                padding *= std::fabs(offset) * 1.2;
-            padding *= common_.scale_factor_;
+            double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+            double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                              (std::fabs(offset) * offset_converter_default_threshold)));
+            double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
             clip_box.pad(padding);
         }
         using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,

--- a/src/agg/process_line_symbolizer.cpp
+++ b/src/agg/process_line_symbolizer.cpp
@@ -140,23 +140,12 @@ void agg_renderer<T0,T1>::process(line_symbolizer const& sym,
     line_rasterizer_enum rasterizer_e = get<line_rasterizer_enum, keys::line_rasterizer>(sym, feature, common_.vars_);
     if (clip)
     {
-        double padding = static_cast<double>(common_.query_extent_.width()/pixmap_.width());
-        double half_stroke = 0.5 * width;
-        if (half_stroke > 1)
-        {
-            padding *= half_stroke;
-        }
-        if (std::fabs(offset) > 0)
-        {
-            padding *= std::fabs(offset) * 1.2;
-        }
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
 
-        padding *= common_.scale_factor_;
         clip_box.pad(padding);
-        // debugging
-        //box2d<double> inverse = query_extent_;
-        //inverse.pad(-padding);
-        //draw_geo_extent(inverse,mapnik::color("red"));
     }
 
     if (rasterizer_e == RASTERIZER_FAST)

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -131,13 +131,11 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/common_.width_);
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
 

--- a/src/cairo/process_line_symbolizer.cpp
+++ b/src/cairo/process_line_symbolizer.cpp
@@ -73,13 +73,11 @@ void cairo_renderer<T>::process(line_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/common_.width_);
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
     using vertex_converter_type =  vertex_converter<clip_line_tag,

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -98,13 +98,11 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/pixmap_.width());
-        double half_stroke = stroke_width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(stroke_width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
 

--- a/src/grid/process_line_symbolizer.cpp
+++ b/src/grid/process_line_symbolizer.cpp
@@ -85,13 +85,11 @@ void grid_renderer<T>::process(line_symbolizer const& sym,
 
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/pixmap_.width());
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
     using vertex_converter_type = vertex_converter<clip_line_tag, clip_poly_tag, transform_tag,


### PR DESCRIPTION
- Fixes issue with clipping being done exactly at the tile border so a line would appear between tile borders.
- Increases the clip size so any offset line that starts inside the tile and is clipped will always be drawn, which was an issue due to the hand-picked [threshold](https://github.com/CartoDB/mapnik/blob/313efc2df1ab1cf3fee37d785e351e11feb814d8/include/mapnik/offset_converter.hpp#L136) in the offset converter. 
- Brings a fix from upstream to avoid filtering closing/moving segments (the "invisible" ones connecting multiple polygons inside a feature for example).

Difference:
* Before:
![image](https://user-images.githubusercontent.com/664253/40982982-dddd6e5e-68de-11e8-8b43-96d8165f6dbb.png)

* After:
![image](https://user-images.githubusercontent.com/664253/40983009-ec942d98-68de-11e8-961f-143b5a076b7a.png)

Pending:
- Update visual tests (a couple more added).
- Performance checks (polygons with offset [several values] using polygonsymbolizer and linesymbolizer, lines with offset [several values] using linesymbolizer).
- Update NEWs