### PR TITLE
Postgis plugin connection manager: Add thread safety to the pool on insert and lookups

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -12,6 +12,8 @@ Changes:
 
  - Fix a change in behaviour introduced in 3.0.15.12 where negative values left shifted changed value. As `<<` is undefined for negative ints, it was changed for an equivalent division but the `agg` library relied on a certain behaviour (e.g. `(-2 << 256) == -1`).
 
+ - Postgis plugin connection manager: Thread safety and remove password from the id from upstream.
+
  - Update dependencies:
     - libpq to 10.7 (was 9.6.2)
     - jpeg_turbo to 1.5.2 (was 1.5.1)

--- a/plugins/input/postgis/connection_manager.hpp
+++ b/plugins/input/postgis/connection_manager.hpp
@@ -115,6 +115,9 @@ public:
 
     bool registerPool(ConnectionCreator<Connection> const& creator,unsigned initialSize,unsigned maxSize)
     {
+#ifdef MAPNIK_THREADSAFE
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         ContType::const_iterator itr = pools_.find(creator.id());
 
         if (itr != pools_.end())
@@ -134,6 +137,9 @@ public:
 
     std::shared_ptr<PoolType> getPool(std::string const& key)
     {
+#ifdef MAPNIK_THREADSAFE
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         ContType::const_iterator itr=pools_.find(key);
         if (itr!=pools_.end())
         {

--- a/plugins/input/postgis/connection_manager.hpp
+++ b/plugins/input/postgis/connection_manager.hpp
@@ -67,7 +67,7 @@ public:
 
     inline std::string id() const
     {
-        return connection_string();
+        return connection_string_safe();
     }
 
     inline std::string connection_string() const

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -28,6 +28,7 @@
 #include <mapnik/geometry_type.hpp>
 #include <mapnik/unicode.hpp>
 #include <mapnik/util/fs.hpp>
+#include "../../../plugins/input/postgis/connection_manager.hpp"
 
 /*
   Compile and run just this test:
@@ -405,4 +406,21 @@ TEST_CASE("postgis") {
 */
 
     }
+}
+
+
+TEST_CASE("ConnectionCreator") {
+
+SECTION("ConnectionCreator::id() should not expose password")
+{
+    ConnectionCreator<Connection> creator(boost::optional<std::string>("host"),
+                                          boost::optional<std::string>("12345"),
+                                          boost::optional<std::string>("dbname"),
+                                          boost::optional<std::string>("user"),
+                                          boost::optional<std::string>("pass"),
+                                          boost::optional<std::string>("111"));
+
+    CHECK(creator.id() == "host=host port=12345 dbname=dbname user=user connect_timeout=111");
+}
+
 }


### PR DESCRIPTION
There were a couple of crashes while registering pools:
```
(gdb) bt
#0  std::string::size (this=<optimized out>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:724
#1  std::string::compare (this=<optimized out>, __str=...) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:2245
#2  std::operator< <char, std::char_traits<char>, std::allocator<char> > (__lhs=..., __rhs=...)
    at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:2589
#3  std::less<std::string>::operator() (this=<optimized out>, __x=..., __y=...)
    at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_function.h:371
#4  std::_Rb_tree<std::string, std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, std::_Select1st<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::_M_get_insert_unique_pos (this=<optimized out>, __k=...)
    at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_tree.h:1456
#5  0x00007fcab16bfae0 in std::_Rb_tree<std::string, std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, std::_Select1st<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::_M_insert_unique<std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >(std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >&&) (
    this=0x7fcab1922138 <mapnik::CreateStatic<ConnectionManager>::create()::static_memory>, 
    __v=<unknown type in /home/ubuntu/www/node-windshaft/releases/20190429113038/node_modules/@carto/mapnik/lib/binding/lib/mapnik/input/postgis.input, CU 0x0, DIE 0x638af>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_tree.h:1498
#6  std::map<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::insert<std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, void>(std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >&&) (this=0x7fcaee7e28f0, 
    __x=<unknown type in /home/ubuntu/www/node-windshaft/releases/20190429113038/node_modules/@carto/mapnik/lib/binding/lib/mapnik/input/postgis.input, CU 0x0, DIE 0x63890>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_map.h:638
#7  ConnectionManager::registerPool (this=0x7fcab1922138 <mapnik::CreateStatic<ConnectionManager>::create()::static_memory>, creator=..., 
    initialSize=<optimized out>, maxSize=<optimized out>) at plugins/input/postgis/connection_manager.hpp:127
#8  0x00007fcab16b15d0 in postgis_datasource::postgis_datasource (this=0x7fc9cc070ae0, params=...) at plugins/input/postgis/postgis_datasource.cpp:144
#9  0x00007fcab16b0342 in create (params=...) at plugins/input/postgis/postgis_datasource.cpp:52
#10 0x00007fcab975ba70 in mapnik::datasource_cache::create (this=<optimized out>, params=...) at src/datasource_cache.cpp:126
#11 0x00007fcab982e02b in mapnik::map_parser::parse_layer (this=0x7fcaee7e3cf0, map=..., node=...) at src/load_map.cpp:819
#12 0x00007fcab9829bf5 in mapnik::map_parser::parse_map_include (this=0x7fcaee7e3cf0, map=..., node=...) at src/load_map.cpp:426
#13 0x00007fcab982754a in mapnik::map_parser::parse_map (this=0x7fcaee7e3cf8, map=..., node=..., base_path=...) at src/load_map.cpp:396
```


```
#0  0x00007f0eed46fcd8 in std::_Rb_tree_insert_and_rebalance(bool, std::_Rb_tree_node_base*, std::_Rb_tree_node_base*, std::_Rb_tree_node_base&) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x00007f0e8b469bb4 in std::_Rb_tree<std::string, std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, std::_Select1st<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::_M_insert_<std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >(std::_Rb_tree_node_base*, std::_Rb_tree_node_base*, std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >&&) (this=0x7f0e8b6cc138 <mapnik::CreateStatic<ConnectionManager>::create()::static_memory>, __x=<optimized out>, __p=<optimized out>, 
    __v=<optimized out>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_tree.h:1145
#2  std::_Rb_tree<std::string, std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, std::_Select1st<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::_M_insert_unique<std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > >(std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >&&) (
    this=0x7f0e8b6cc138 <mapnik::CreateStatic<ConnectionManager>::create()::static_memory>, 
    __v=<unknown type in /home/ubuntu/www/node-windshaft/releases/20190429113038/node_modules/@carto/mapnik/lib/binding/lib/mapnik/input/postgis.input, CU 0x0, DIE 0x638af>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_tree.h:1501
#3  std::map<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> >, std::less<std::string>, std::allocator<std::pair<std::string const, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > > > >::insert<std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >, void>(std::pair<std::string, std::shared_ptr<mapnik::Pool<Connection, ConnectionCreator> > >&&) (this=0x7f0ecdff98f0, 
    __x=<unknown type in /home/ubuntu/www/node-windshaft/releases/20190429113038/node_modules/@carto/mapnik/lib/binding/lib/mapnik/input/postgis.input, CU 0x0, DIE 0x63890>) at /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/stl_map.h:638
#4  ConnectionManager::registerPool (this=0x7f0e8b6cc138 <mapnik::CreateStatic<ConnectionManager>::create()::static_memory>, creator=..., 
    initialSize=<optimized out>, maxSize=<optimized out>) at plugins/input/postgis/connection_manager.hpp:127
#5  0x00007f0e8b45b5d0 in postgis_datasource::postgis_datasource (this=0x7f0e2c1a4d00, params=...) at plugins/input/postgis/postgis_datasource.cpp:144
#6  0x00007f0e8b45a342 in create (params=...) at plugins/input/postgis/postgis_datasource.cpp:52
#7  0x00007f0e92df5a70 in mapnik::datasource_cache::create (this=<optimized out>, params=...) at src/datasource_cache.cpp:126
``` 