### PR TITLE
Populate precision

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,12 @@
 # CARTO Mapnik Changelog
 
+## 3.0.15.17
+
+**Release date**: 2019-07-09
+
+Changes:
+ - Improve precision when outputting variables into Postgis plugin SQL queries.
+
 ## 3.0.15.16
 
 **Release date**: 2019-05-20

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -544,6 +544,7 @@ std::string postgis_datasource::populate_tokens(
                                 bool intersect) const
 {
     std::ostringstream populated_sql;
+    populated_sql.precision(12); // Increase precision tro avoid issues with floating point values
     std::cmatch m;
     char const* start = sql.data();
     char const* end = start + sql.size();

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -544,6 +544,7 @@ std::string postgis_datasource::populate_tokens(
                                 bool intersect) const
 {
     std::ostringstream populated_sql;
+    populated_sql << std::fixed;
     populated_sql.precision(12); // Increase precision tro avoid issues with floating point values
     std::cmatch m;
     char const* start = sql.data();


### PR DESCRIPTION
This enable us to remove hacks around aggregation also when using Mapnik

With this and some test modifications all Windshaft-cartodb tests pass both with pg-mvt and mapnik.